### PR TITLE
Update codecov and CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions) 
+[![CI Status](https://github.com/AY2122S2-CS2103T-T09-1/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2122S2-CS2103T-T09-1/tp/actions)
 [![codecov](https://codecov.io/gh/AY2122S2-CS2103T-T09-1/tp/branch/master/graph/badge.svg?token=F2HBLHWFOZ)](https://codecov.io/gh/AY2122S2-CS2103T-T09-1/tp)
 
 ![Ui](docs/images/Ui.png)


### PR DESCRIPTION
Codecov and CI status badge on README.md links to the AddressBook Level 3's repository.
Updated both badges to link to Harmonia's repository.