### PR TITLE
Search by deadline

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -60,7 +60,7 @@ public class FindCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredTaskList((namePredicate.or(tagPredicate)).and(deadlinePredicate));
+        model.updateFilteredTaskList(namePredicate.and(tagPredicate).and(deadlinePredicate));
         return new CommandResult(
                 String.format(Messages.MESSAGE_TASKS_LISTED_OVERVIEW, model.getFilteredTaskList().size()));
     }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,11 +1,14 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.tag.TagContainsKeywordsPredicate;
+import seedu.address.model.task.DeadlineInRangePredicate;
 import seedu.address.model.task.NameContainsKeywordsPredicate;
 
 /**
@@ -17,11 +20,16 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all tasks whose names or tags contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers. "
+            + "If a range of date is specified, only the tasks with a deadline that falls within the range "
+            + "will be displayed.\n"
             + "Parameters (must contain at least one keyword): "
             + "[NAME_KEYWORD] "
-            + "[" + PREFIX_TAG + "TAG_KEYWORD]\n"
-            + "Example: " + COMMAND_WORD + " tutorial assignment t/test t/CS2103T";
+            + "[" + PREFIX_TAG + "TAG_KEYWORD]"
+            + "[" + PREFIX_START + "YYYY-MM-DD]"
+            + "[" + PREFIX_END + "YYYY-MM-DD]\n"
+            + "Example: " + COMMAND_WORD
+            + " tutorial assignment t/test t/CS2103T start/2022-03-23 end/2022-03-28";
 
     /** Predicate that tests whether task name contains any given keyword */
     private final NameContainsKeywordsPredicate namePredicate;
@@ -29,21 +37,29 @@ public class FindCommand extends Command {
     /** Predicate that tests whether tag contains any given keywords */
     private final TagContainsKeywordsPredicate tagPredicate;
 
+    /** Predicate that tests whether the deadline of a task is within the given date range */
+    private final DeadlineInRangePredicate deadlinePredicate;
+
     /**
      * Constructor for FindCommand.
      *
-     * @param namePredicate predicate that tests whether task name contains any given keywords.
-     * @param tagPredicate predicate that tests whether tag contains any given keywords.
+     * @param namePredicate predicate that tests whether task name contains any given keywords
+     * @param tagPredicate predicate that tests whether tag contains any given keywords
+     * @param deadlinePredicate predicate that tests whether the deadline is in the range
      */
-    public FindCommand(NameContainsKeywordsPredicate namePredicate, TagContainsKeywordsPredicate tagPredicate) {
+    public FindCommand(NameContainsKeywordsPredicate namePredicate,
+                       TagContainsKeywordsPredicate tagPredicate,
+                       DeadlineInRangePredicate deadlinePredicate) {
+
         this.namePredicate = namePredicate;
         this.tagPredicate = tagPredicate;
+        this.deadlinePredicate = deadlinePredicate;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredTaskList(namePredicate.or(tagPredicate));
+        model.updateFilteredTaskList(namePredicate.or(tagPredicate).and(deadlinePredicate));
         return new CommandResult(
                 String.format(Messages.MESSAGE_TASKS_LISTED_OVERVIEW, model.getFilteredTaskList().size()));
     }
@@ -53,6 +69,7 @@ public class FindCommand extends Command {
         return other == this // short circuit if same object
                 || (other instanceof FindCommand // instanceof handles nulls
                 && namePredicate.equals(((FindCommand) other).namePredicate)
-                && tagPredicate.equals(((FindCommand) other).tagPredicate)); // state check
+                && tagPredicate.equals(((FindCommand) other).tagPredicate)
+                && deadlinePredicate.equals(((FindCommand) other).deadlinePredicate));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -24,12 +25,12 @@ public class FindCommand extends Command {
             + "If a range of date is specified, only the tasks with a deadline that falls within the range "
             + "will be displayed.\n"
             + "Parameters (must contain at least one keyword): "
-            + "[NAME_KEYWORD] "
-            + "[" + PREFIX_TAG + "TAG_KEYWORD]"
-            + "[" + PREFIX_START + "YYYY-MM-DD]"
+            + "[" + PREFIX_NAME + "NAME_KEYWORD] "
+            + "[" + PREFIX_TAG + "TAG_KEYWORD] "
+            + "[" + PREFIX_START + "YYYY-MM-DD] "
             + "[" + PREFIX_END + "YYYY-MM-DD]\n"
             + "Example: " + COMMAND_WORD
-            + " tutorial assignment t/test t/CS2103T start/2022-03-23 end/2022-03-28";
+            + " tutorial n/assignment t/test t/CS2103T start/2022-03-23 end/2022-03-28";
 
     /** Predicate that tests whether task name contains any given keyword */
     private final NameContainsKeywordsPredicate namePredicate;
@@ -59,7 +60,7 @@ public class FindCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredTaskList(namePredicate.or(tagPredicate).and(deadlinePredicate));
+        model.updateFilteredTaskList((namePredicate.or(tagPredicate)).and(deadlinePredicate));
         return new CommandResult(
                 String.format(Messages.MESSAGE_TASKS_LISTED_OVERVIEW, model.getFilteredTaskList().size()));
     }

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -71,6 +71,14 @@ public class ArgumentTokenizer {
      */
     private static int findPrefixPosition(String argsString, String prefix, int fromIndex) {
         int prefixIndex = argsString.indexOf(" " + prefix, fromIndex);
+        if (prefixIndex == -1) {
+            // If prefix index not found, try another whitespace.
+            prefixIndex = argsString.indexOf("\n" + prefix, fromIndex);
+        }
+        if (prefixIndex == -1) {
+            // If prefix index not found, try another whitespace.
+            prefixIndex = argsString.indexOf("\t" + prefix, fromIndex);
+        }
         return prefixIndex == -1 ? -1
                 : prefixIndex + 1; // +1 as offset for whitespace
     }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,4 +12,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_PRIORITY = new Prefix("p/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 
+    /* Prefix definitions for non-attribute fields */
+    public static final Prefix PREFIX_START = new Prefix("start/");
+    public static final Prefix PREFIX_END = new Prefix("end/");
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.ArrayList;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -50,7 +49,7 @@ public class FindCommandParser implements Parser<FindCommand> {
             endDate = ParserUtil.parseDeadline(argMultimap.getValue(PREFIX_END).get());
         }
 
-        return new FindCommand(new NameContainsKeywordsPredicate(new ArrayList<>(nameKeywords)),
+        return new FindCommand(new NameContainsKeywordsPredicate(nameKeywords),
                 new TagContainsKeywordsPredicate(tagKeywords),
                 new DeadlineInRangePredicate(startDate, endDate));
     }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -10,10 +10,8 @@ import java.util.ArrayList;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.tag.Tag;
 import seedu.address.model.tag.TagContainsKeywordsPredicate;
 import seedu.address.model.task.Deadline;
 import seedu.address.model.task.DeadlineInRangePredicate;

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -59,27 +59,6 @@ public class FindCommandParser implements Parser<FindCommand> {
             endDate = ParserUtil.parseDeadline(argMultimap.getValue(PREFIX_END).get());
         }
 
-//        String trimmedArgs = args.trim();
-//        if (trimmedArgs.isEmpty()) {
-//            throw new ParseException(
-//                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-//        }
-//
-//        String[] allKeywords = trimmedArgs.split("\\s+");
-//
-//        List<String> nameKeywords = Arrays.asList(allKeywords);
-//
-//        Set<String> tagKeywords = new HashSet<>();
-//        for (String keyword : allKeywords) {
-//            if (keyword.startsWith(PREFIX_TAG.toString())) {
-//                String keywordWithoutPrefix = keyword.replace(PREFIX_TAG.toString(), "");
-//                if (!keywordWithoutPrefix.equals("")) {
-//                    tagKeywords.add(keywordWithoutPrefix);
-//                }
-//            }
-//        }
-
-
         return new FindCommand(new NameContainsKeywordsPredicate(new ArrayList<>(nameKeywords)),
                 new TagContainsKeywordsPredicate(tagKeywords),
                 new DeadlineInRangePredicate(startDate, endDate));

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,19 +1,12 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -44,6 +44,7 @@ public class FindCommandParser implements Parser<FindCommand> {
             }
         }
 
+
         return new FindCommand(new NameContainsKeywordsPredicate(nameKeywords),
                 new TagContainsKeywordsPredicate(tagKeywords));
     }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,16 +1,29 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
+import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
 import seedu.address.model.tag.TagContainsKeywordsPredicate;
+import seedu.address.model.task.Deadline;
+import seedu.address.model.task.DeadlineInRangePredicate;
 import seedu.address.model.task.NameContainsKeywordsPredicate;
 
 /**
@@ -24,29 +37,63 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TAG, PREFIX_START,
+                        PREFIX_END);
+
+        if (!anyPrefixPresent(argMultimap, PREFIX_NAME, PREFIX_TAG, PREFIX_START, PREFIX_END)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] allKeywords = trimmedArgs.split("\\s+");
+        Set<String> nameKeywords = ParserUtil.parseKeywords(argMultimap.getAllValues(PREFIX_NAME));
+        Set<String> tagKeywords = ParserUtil.parseKeywords(argMultimap.getAllValues(PREFIX_TAG));
+        Deadline startDate = null;
+        Deadline endDate = null;
 
-        List<String> nameKeywords = Arrays.asList(allKeywords);
-
-        Set<String> tagKeywords = new HashSet<>();
-        for (String keyword : allKeywords) {
-            if (keyword.startsWith(PREFIX_TAG.toString())) {
-                String keywordWithoutPrefix = keyword.replace(PREFIX_TAG.toString(), "");
-                if (!keywordWithoutPrefix.equals("")) {
-                    tagKeywords.add(keywordWithoutPrefix);
-                }
-            }
+        if (argMultimap.getValue(PREFIX_START).isPresent()) {
+            startDate = ParserUtil.parseDeadline(argMultimap.getValue(PREFIX_START).get());
         }
 
+        if (argMultimap.getValue(PREFIX_END).isPresent()) {
+            endDate = ParserUtil.parseDeadline(argMultimap.getValue(PREFIX_END).get());
+        }
 
-        return new FindCommand(new NameContainsKeywordsPredicate(nameKeywords),
-                new TagContainsKeywordsPredicate(tagKeywords));
+//        String trimmedArgs = args.trim();
+//        if (trimmedArgs.isEmpty()) {
+//            throw new ParseException(
+//                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+//        }
+//
+//        String[] allKeywords = trimmedArgs.split("\\s+");
+//
+//        List<String> nameKeywords = Arrays.asList(allKeywords);
+//
+//        Set<String> tagKeywords = new HashSet<>();
+//        for (String keyword : allKeywords) {
+//            if (keyword.startsWith(PREFIX_TAG.toString())) {
+//                String keywordWithoutPrefix = keyword.replace(PREFIX_TAG.toString(), "");
+//                if (!keywordWithoutPrefix.equals("")) {
+//                    tagKeywords.add(keywordWithoutPrefix);
+//                }
+//            }
+//        }
+
+
+        return new FindCommand(new NameContainsKeywordsPredicate(new ArrayList<>(nameKeywords)),
+                new TagContainsKeywordsPredicate(tagKeywords),
+                new DeadlineInRangePredicate(startDate, endDate));
+    }
+
+    /**
+     * Checks whether there is at least one prefix present.
+     *
+     * @param argumentMultimap the {@code ArgumentMultimap} to be checked
+     * @param prefixes the prefixes to be checked
+     * @return true if there is any prefix present in {@code argumentMultimap}
+     */
+    private static boolean anyPrefixPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -124,4 +124,14 @@ public class ParserUtil {
         }
         return new Deadline(trimmedDeadline);
     }
+
+    /**
+     * Parses {@code Collection<String> keywords} into a {@code Set<String>}.
+     */
+    public static Set<String> parseKeywords(Collection<String> keywords) throws ParseException {
+        requireNonNull(keywords);
+        final Set<String> keywordSet = new HashSet<>();
+        keywordSet.addAll(keywords);
+        return keywordSet;
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -131,7 +132,15 @@ public class ParserUtil {
     public static Set<String> parseKeywords(Collection<String> keywords) throws ParseException {
         requireNonNull(keywords);
         final Set<String> keywordSet = new HashSet<>();
-        keywordSet.addAll(keywords);
+        for (String keyword : keywords) {
+            if (keyword.isEmpty()) {
+                throw new ParseException("A keyword can't be empty!");
+            }
+            if (keyword.split("\\s+").length > 1) {
+                throw new ParseException("A keyword can't contain any whitespace!");
+            }
+            keywordSet.add(keyword);
+        }
         return keywordSet;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.util.Collection;
 import java.util.HashSet;

--- a/src/main/java/seedu/address/model/tag/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/tag/TagContainsKeywordsPredicate.java
@@ -24,8 +24,10 @@ public class TagContainsKeywordsPredicate implements Predicate<Task> {
 
     @Override
     public boolean test(Task task) {
+        if (keywords.size() == 0) {
+            return true;
+        }
         Set<Tag> tags = task.getTags();
-        System.out.println("tag test: " + task.toString());
         for (Tag tag : tags) {
             boolean containsKeyword = keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(tag.tagName, keyword));

--- a/src/main/java/seedu/address/model/tag/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/tag/TagContainsKeywordsPredicate.java
@@ -25,6 +25,7 @@ public class TagContainsKeywordsPredicate implements Predicate<Task> {
     @Override
     public boolean test(Task task) {
         Set<Tag> tags = task.getTags();
+        System.out.println("tag test: " + task.toString());
         for (Tag tag : tags) {
             boolean containsKeyword = keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(tag.tagName, keyword));

--- a/src/main/java/seedu/address/model/tag/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/tag/TagContainsKeywordsPredicate.java
@@ -44,5 +44,4 @@ public class TagContainsKeywordsPredicate implements Predicate<Task> {
                 || (other instanceof TagContainsKeywordsPredicate // instanceof handles nulls
                 && keywords.equals(((TagContainsKeywordsPredicate) other).keywords)); // state check
     }
-
 }

--- a/src/main/java/seedu/address/model/task/Deadline.java
+++ b/src/main/java/seedu/address/model/task/Deadline.java
@@ -10,12 +10,14 @@ import java.time.format.DateTimeParseException;
  * Represents a Task's deadline in the task list.
  * Guarantees: immutable; is valid as declared in {@link #isValidDeadline(String)}
  */
-public class Deadline {
+public class Deadline implements Comparable<Deadline> {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Deadlines should be in the format YYYY-MM-DD";
     public final String value;
     private final LocalDate localDateValue;
+    static final Deadline MIN_DEADLINE = new Deadline(LocalDate.MIN);
+    static final Deadline MAX_DEADLINE = new Deadline(LocalDate.MAX);
 
     /**
      * Constructs a {@code Deadline}. Accepts date in the format of yyyy-mm-dd.
@@ -27,6 +29,17 @@ public class Deadline {
         checkArgument(isValidDeadline(deadline), MESSAGE_CONSTRAINTS);
         value = deadline;
         localDateValue = LocalDate.parse(deadline);
+    }
+
+    /**
+     * Constructs a {@code Deadline} using {@code LocalDate}.
+     *
+     * @param localDate a non-null {@code LocalDate}
+     */
+    private Deadline(LocalDate localDate) {
+        requireNonNull(localDate);
+        this.localDateValue = localDate;
+        this.value = localDate.toString();  // Not used.
     }
 
     /**
@@ -58,4 +71,8 @@ public class Deadline {
         return value.hashCode();
     }
 
+    @Override
+    public int compareTo(Deadline d) {
+        return this.localDateValue.compareTo(d.localDateValue);
+    }
 }

--- a/src/main/java/seedu/address/model/task/Deadline.java
+++ b/src/main/java/seedu/address/model/task/Deadline.java
@@ -12,10 +12,11 @@ import java.time.format.DateTimeParseException;
  */
 public class Deadline implements Comparable<Deadline> {
 
-    static final Deadline MIN_DEADLINE = new Deadline(LocalDate.MIN);
-    static final Deadline MAX_DEADLINE = new Deadline(LocalDate.MAX);
     public static final String MESSAGE_CONSTRAINTS =
             "Deadlines should be in the format YYYY-MM-DD";
+    static final Deadline MIN_DEADLINE = new Deadline(LocalDate.MIN);
+    static final Deadline MAX_DEADLINE = new Deadline(LocalDate.MAX);
+
     public final String value;
     private final LocalDate localDateValue;
 

--- a/src/main/java/seedu/address/model/task/Deadline.java
+++ b/src/main/java/seedu/address/model/task/Deadline.java
@@ -12,12 +12,13 @@ import java.time.format.DateTimeParseException;
  */
 public class Deadline implements Comparable<Deadline> {
 
+    static final Deadline MIN_DEADLINE = new Deadline(LocalDate.MIN);
+    static final Deadline MAX_DEADLINE = new Deadline(LocalDate.MAX);
     public static final String MESSAGE_CONSTRAINTS =
             "Deadlines should be in the format YYYY-MM-DD";
     public final String value;
     private final LocalDate localDateValue;
-    static final Deadline MIN_DEADLINE = new Deadline(LocalDate.MIN);
-    static final Deadline MAX_DEADLINE = new Deadline(LocalDate.MAX);
+
 
     /**
      * Constructs a {@code Deadline}. Accepts date in the format of yyyy-mm-dd.
@@ -39,7 +40,7 @@ public class Deadline implements Comparable<Deadline> {
     private Deadline(LocalDate localDate) {
         requireNonNull(localDate);
         this.localDateValue = localDate;
-        this.value = localDate.toString();  // Not used.
+        this.value = localDate.toString(); // Not used.
     }
 
     /**

--- a/src/main/java/seedu/address/model/task/DeadlineInRangePredicate.java
+++ b/src/main/java/seedu/address/model/task/DeadlineInRangePredicate.java
@@ -1,0 +1,44 @@
+package seedu.address.model.task;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static seedu.address.model.task.Deadline.MAX_DEADLINE;
+import static seedu.address.model.task.Deadline.MIN_DEADLINE;
+
+/**
+ * Tests that a {@code Task}'s {@code Deadline} is within the range given.
+ */
+public class DeadlineInRangePredicate implements Predicate<Task> {
+
+    private final Optional<Deadline> startDate;
+    private final Optional<Deadline> endDate;
+
+    /**
+     * Constructor for DeadlineInRangePredicate.
+     *
+     * @param startDate The lower bound of the range of deadline (inclusive).
+     *                  If the given value is null, it means that there is no lower bound.
+     * @param endDate the upper bound of the range of deadline (inclusive)
+     *                If the given value is null, it means that there is no upper bound.
+     */
+    public DeadlineInRangePredicate(Deadline startDate, Deadline endDate) {
+        this.startDate = Optional.ofNullable(startDate);
+        this.endDate = Optional.ofNullable(endDate);
+    }
+
+    @Override
+    public boolean test(Task task) {
+        Deadline deadline = task.getDeadline();
+        return deadline.compareTo(startDate.orElse(MIN_DEADLINE)) >= 0
+                && deadline.compareTo(endDate.orElse(MAX_DEADLINE)) <= 0;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeadlineInRangePredicate // instanceof handles nulls
+                && startDate.equals(((DeadlineInRangePredicate) other).startDate)
+                && endDate.equals(((DeadlineInRangePredicate) other).endDate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/task/DeadlineInRangePredicate.java
+++ b/src/main/java/seedu/address/model/task/DeadlineInRangePredicate.java
@@ -30,6 +30,7 @@ public class DeadlineInRangePredicate implements Predicate<Task> {
     @Override
     public boolean test(Task task) {
         Deadline deadline = task.getDeadline();
+        System.out.println("deadline test: " + task.toString());
         return deadline.compareTo(startDate.orElse(MIN_DEADLINE)) >= 0
                 && deadline.compareTo(endDate.orElse(MAX_DEADLINE)) <= 0;
     }

--- a/src/main/java/seedu/address/model/task/DeadlineInRangePredicate.java
+++ b/src/main/java/seedu/address/model/task/DeadlineInRangePredicate.java
@@ -30,7 +30,6 @@ public class DeadlineInRangePredicate implements Predicate<Task> {
     @Override
     public boolean test(Task task) {
         Deadline deadline = task.getDeadline();
-        System.out.println("deadline test: " + task.toString());
         return deadline.compareTo(startDate.orElse(MIN_DEADLINE)) >= 0
                 && deadline.compareTo(endDate.orElse(MAX_DEADLINE)) <= 0;
     }

--- a/src/main/java/seedu/address/model/task/DeadlineInRangePredicate.java
+++ b/src/main/java/seedu/address/model/task/DeadlineInRangePredicate.java
@@ -1,10 +1,10 @@
 package seedu.address.model.task;
 
-import java.util.Optional;
-import java.util.function.Predicate;
-
 import static seedu.address.model.task.Deadline.MAX_DEADLINE;
 import static seedu.address.model.task.Deadline.MIN_DEADLINE;
+
+import java.util.Optional;
+import java.util.function.Predicate;
 
 /**
  * Tests that a {@code Task}'s {@code Deadline} is within the range given.

--- a/src/main/java/seedu/address/model/task/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/task/NameContainsKeywordsPredicate.java
@@ -17,6 +17,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Task> {
 
     @Override
     public boolean test(Task task) {
+        System.out.println("name test: " + task.toString());
         return keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(task.getName().fullName, keyword));
     }

--- a/src/main/java/seedu/address/model/task/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/task/NameContainsKeywordsPredicate.java
@@ -17,7 +17,10 @@ public class NameContainsKeywordsPredicate implements Predicate<Task> {
 
     @Override
     public boolean test(Task task) {
-        System.out.println("name test: " + task.toString());
+        if (keywords.size() == 0) {
+            // If the list passed in is empty, returns true.
+            return true;
+        }
         return keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(task.getName().fullName, keyword));
     }

--- a/src/main/java/seedu/address/model/task/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/task/NameContainsKeywordsPredicate.java
@@ -1,6 +1,7 @@
 package seedu.address.model.task;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
@@ -9,9 +10,9 @@ import seedu.address.commons.util.StringUtil;
  * Tests that a {@code Task}'s {@code Name} matches any of the keywords given.
  */
 public class NameContainsKeywordsPredicate implements Predicate<Task> {
-    private final List<String> keywords;
+    private final Set<String> keywords;
 
-    public NameContainsKeywordsPredicate(List<String> keywords) {
+    public NameContainsKeywordsPredicate(Set<String> keywords) {
         this.keywords = keywords;
     }
 

--- a/src/main/java/seedu/address/model/task/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/task/NameContainsKeywordsPredicate.java
@@ -1,6 +1,5 @@
 package seedu.address.model.task;
 
-import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -10,7 +10,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -11,6 +11,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
@@ -128,7 +129,7 @@ public class CommandTestUtil {
 
         Task task = model.getFilteredTaskList().get(targetIndex.getZeroBased());
         final String[] splitName = task.getName().fullName.split("\\s+");
-        model.updateFilteredTaskList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+        model.updateFilteredTaskList(new NameContainsKeywordsPredicate(Collections.singleton(splitName[0])));
 
         assertEquals(1, model.getFilteredTaskList().size());
     }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -21,6 +21,8 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.tag.TagContainsKeywordsPredicate;
+import seedu.address.model.task.Deadline;
+import seedu.address.model.task.DeadlineInRangePredicate;
 import seedu.address.model.task.NameContainsKeywordsPredicate;
 
 /**
@@ -40,15 +42,22 @@ public class FindCommandTest {
                 new TagContainsKeywordsPredicate(new HashSet<>(Collections.singletonList("firstTag")));
         TagContainsKeywordsPredicate secondTagPredicate =
                 new TagContainsKeywordsPredicate(new HashSet<>(Collections.singletonList("secondTag")));
+        DeadlineInRangePredicate firstDeadlinePredicate =
+                new DeadlineInRangePredicate(new Deadline("2022-03-04"), new Deadline("2022-03-05"));
+        DeadlineInRangePredicate secondDeadlinePredicate =
+                new DeadlineInRangePredicate(new Deadline("2022-03-09"), new Deadline("2022-03-22"));
 
-        FindCommand findFirstCommand = new FindCommand(firstNamePredicate, firstTagPredicate);
-        FindCommand findSecondCommand = new FindCommand(secondNamePredicate, secondTagPredicate);
+        FindCommand findFirstCommand =
+                new FindCommand(firstNamePredicate, firstTagPredicate, firstDeadlinePredicate);
+        FindCommand findSecondCommand =
+                new FindCommand(secondNamePredicate, secondTagPredicate, secondDeadlinePredicate);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstNamePredicate, firstTagPredicate);
+        FindCommand findFirstCommandCopy =
+                new FindCommand(firstNamePredicate, firstTagPredicate, firstDeadlinePredicate);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false
@@ -62,45 +71,53 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noTaskFound() {
+    public void execute_zeroKeywordsAndVeryLargeDateRange_noTaskFound() {
         String expectedMessage = String.format(MESSAGE_TASKS_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate namePredicate = prepareNamePredicate(" ");
         TagContainsKeywordsPredicate tagPredicate = prepareTagPredicate(" ");
-        FindCommand command = new FindCommand(namePredicate, tagPredicate);
-        expectedModel.updateFilteredTaskList(namePredicate.or(tagPredicate));
+        DeadlineInRangePredicate deadlinePredicate =
+                new DeadlineInRangePredicate(null, null);
+        FindCommand command = new FindCommand(namePredicate, tagPredicate, deadlinePredicate);
+        expectedModel.updateFilteredTaskList((namePredicate.or(tagPredicate)).and(deadlinePredicate));
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredTaskList());
     }
 
     @Test
-    public void execute_multipleNameKeywordsAndZeroTagKeywords_multipleTasksFound() {
+    public void execute_multipleNameKeywordsAndZeroTagKeywordsAndVeryLargeDateRange_multipleTasksFound() {
         String expectedMessage = String.format(MESSAGE_TASKS_LISTED_OVERVIEW, 2);
         NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Alice Project");
         TagContainsKeywordsPredicate tagPredicate = prepareTagPredicate(" ");
-        FindCommand command = new FindCommand(namePredicate, tagPredicate);
-        expectedModel.updateFilteredTaskList(namePredicate.or(tagPredicate));
+        DeadlineInRangePredicate deadlinePredicate =
+                new DeadlineInRangePredicate(null, null);
+        FindCommand command = new FindCommand(namePredicate, tagPredicate, deadlinePredicate);
+        expectedModel.updateFilteredTaskList((namePredicate.or(tagPredicate)).and(deadlinePredicate));
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CS2103T_PROJECT, MEET_ALICE), model.getFilteredTaskList());
     }
 
     @Test
-    public void execute_zeroNameKeywordsAndMultipleTagKeywords_multipleTasksFound() {
+    public void execute_zeroNameKeywordsAndMultipleTagKeywordsAndVeryLargeDateRange_multipleTasksFound() {
         String expectedMessage = String.format(MESSAGE_TASKS_LISTED_OVERVIEW, 3);
         NameContainsKeywordsPredicate namePredicate = prepareNamePredicate(" ");
         TagContainsKeywordsPredicate tagPredicate = prepareTagPredicate("exam CS2103T");
-        FindCommand command = new FindCommand(namePredicate, tagPredicate);
-        expectedModel.updateFilteredTaskList(namePredicate.or(tagPredicate));
+        DeadlineInRangePredicate deadlinePredicate =
+                new DeadlineInRangePredicate(null, null);
+        FindCommand command = new FindCommand(namePredicate, tagPredicate, deadlinePredicate);
+        expectedModel.updateFilteredTaskList((namePredicate.or(tagPredicate)).and(deadlinePredicate));
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CS2103T_PROJECT, CS2105_FINALS, CS2105_MIDTERM), model.getFilteredTaskList());
     }
 
     @Test
-    public void execute_multipleNameKeywordsAndMultipleTagKeywords_multipleTasksFound() {
+    public void execute_multipleNameKeywordsAndMultipleTagKeywordsAndVeryLargeDateRange_multipleTasksFound() {
         String expectedMessage = String.format(MESSAGE_TASKS_LISTED_OVERVIEW, 4);
         NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Alice Project");
         TagContainsKeywordsPredicate tagPredicate = prepareTagPredicate("exam cs2103t");
-        FindCommand command = new FindCommand(namePredicate, tagPredicate);
-        expectedModel.updateFilteredTaskList(namePredicate.or(tagPredicate));
+        DeadlineInRangePredicate deadlinePredicate =
+                new DeadlineInRangePredicate(null, null);
+        FindCommand command = new FindCommand(namePredicate, tagPredicate, deadlinePredicate);
+        expectedModel.updateFilteredTaskList((namePredicate.or(tagPredicate)).and(deadlinePredicate));
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CS2103T_PROJECT, CS2105_FINALS, CS2105_MIDTERM, MEET_ALICE),
                 model.getFilteredTaskList());

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -14,6 +14,7 @@ import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -35,9 +36,9 @@ public class FindCommandTest {
     @Test
     public void equals() {
         NameContainsKeywordsPredicate firstNamePredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("firstName"));
+                new NameContainsKeywordsPredicate(Collections.singleton("firstName"));
         NameContainsKeywordsPredicate secondNamePredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("secondName"));
+                new NameContainsKeywordsPredicate(Collections.singleton("secondName"));
         TagContainsKeywordsPredicate firstTagPredicate =
                 new TagContainsKeywordsPredicate(new HashSet<>(Collections.singletonList("firstTag")));
         TagContainsKeywordsPredicate secondTagPredicate =
@@ -72,15 +73,15 @@ public class FindCommandTest {
 
     @Test
     public void execute_zeroKeywordsAndVeryLargeDateRange_noTaskFound() {
-        String expectedMessage = String.format(MESSAGE_TASKS_LISTED_OVERVIEW, 0);
+        String expectedMessage = String.format(MESSAGE_TASKS_LISTED_OVERVIEW, 5);
         NameContainsKeywordsPredicate namePredicate = prepareNamePredicate(" ");
         TagContainsKeywordsPredicate tagPredicate = prepareTagPredicate(" ");
         DeadlineInRangePredicate deadlinePredicate =
                 new DeadlineInRangePredicate(null, null);
         FindCommand command = new FindCommand(namePredicate, tagPredicate, deadlinePredicate);
-        expectedModel.updateFilteredTaskList((namePredicate.or(tagPredicate)).and(deadlinePredicate));
+        expectedModel.updateFilteredTaskList(namePredicate.and(tagPredicate).and(deadlinePredicate));
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredTaskList());
+        assertEquals(expectedModel.getFilteredTaskList(), model.getFilteredTaskList());
     }
 
     @Test
@@ -91,7 +92,7 @@ public class FindCommandTest {
         DeadlineInRangePredicate deadlinePredicate =
                 new DeadlineInRangePredicate(null, null);
         FindCommand command = new FindCommand(namePredicate, tagPredicate, deadlinePredicate);
-        expectedModel.updateFilteredTaskList((namePredicate.or(tagPredicate)).and(deadlinePredicate));
+        expectedModel.updateFilteredTaskList(namePredicate.and(tagPredicate).and(deadlinePredicate));
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CS2103T_PROJECT, MEET_ALICE), model.getFilteredTaskList());
     }
@@ -104,22 +105,22 @@ public class FindCommandTest {
         DeadlineInRangePredicate deadlinePredicate =
                 new DeadlineInRangePredicate(null, null);
         FindCommand command = new FindCommand(namePredicate, tagPredicate, deadlinePredicate);
-        expectedModel.updateFilteredTaskList((namePredicate.or(tagPredicate)).and(deadlinePredicate));
+        expectedModel.updateFilteredTaskList(namePredicate.and(tagPredicate).and(deadlinePredicate));
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CS2103T_PROJECT, CS2105_FINALS, CS2105_MIDTERM), model.getFilteredTaskList());
     }
 
     @Test
     public void execute_multipleNameKeywordsAndMultipleTagKeywordsAndVeryLargeDateRange_multipleTasksFound() {
-        String expectedMessage = String.format(MESSAGE_TASKS_LISTED_OVERVIEW, 4);
+        String expectedMessage = String.format(MESSAGE_TASKS_LISTED_OVERVIEW, 1);
         NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Alice Project");
         TagContainsKeywordsPredicate tagPredicate = prepareTagPredicate("exam cs2103t");
         DeadlineInRangePredicate deadlinePredicate =
                 new DeadlineInRangePredicate(null, null);
         FindCommand command = new FindCommand(namePredicate, tagPredicate, deadlinePredicate);
-        expectedModel.updateFilteredTaskList((namePredicate.or(tagPredicate)).and(deadlinePredicate));
+        expectedModel.updateFilteredTaskList(namePredicate.and(tagPredicate).and(deadlinePredicate));
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CS2103T_PROJECT, CS2105_FINALS, CS2105_MIDTERM, MEET_ALICE),
+        assertEquals(expectedModel.getFilteredTaskList(),
                 model.getFilteredTaskList());
     }
 
@@ -127,7 +128,7 @@ public class FindCommandTest {
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
     private NameContainsKeywordsPredicate prepareNamePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+        return new NameContainsKeywordsPredicate(Set.of(userInput.split("\\s+")));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.tag.TagContainsKeywordsPredicate;
-import seedu.address.model.task.Deadline;
 import seedu.address.model.task.DeadlineInRangePredicate;
 import seedu.address.model.task.NameContainsKeywordsPredicate;
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_CS2103T;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_TEST;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -13,6 +14,8 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.tag.TagContainsKeywordsPredicate;
+import seedu.address.model.task.Deadline;
+import seedu.address.model.task.DeadlineInRangePredicate;
 import seedu.address.model.task.NameContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
@@ -30,20 +33,23 @@ public class FindCommandParserTest {
         // both name and tag keywords specified
         FindCommand expectedFindCommand = new FindCommand(
                 new NameContainsKeywordsPredicate(Arrays.asList("Tutorial", "Midterm", "t/CS2103T", "t/Test")),
-                new TagContainsKeywordsPredicate(new HashSet<>(Arrays.asList("CS2103T", "Test"))));
+                new TagContainsKeywordsPredicate(new HashSet<>(Arrays.asList("CS2103T", "Test"))),
+                new DeadlineInRangePredicate(null, null));
 
         // name and tag keywords specified, no leading and trailing whitespaces
-        assertParseSuccess(parser, "Tutorial Midterm" + TAG_DESC_CS2103T + TAG_DESC_TEST, expectedFindCommand);
+        assertParseSuccess(parser, PREFIX_NAME + " Tutorial " + PREFIX_NAME + " Midterm"
+                + TAG_DESC_CS2103T + TAG_DESC_TEST, expectedFindCommand);
 
         // name and tag keywords specified, multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Tutorial \n \t Midterm \t" + TAG_DESC_CS2103T + "\n\t" + TAG_DESC_TEST,
-                expectedFindCommand);
+        assertParseSuccess(parser, PREFIX_NAME + " \n Tutorial \n" + PREFIX_NAME + " \t Midterm \t"
+                + TAG_DESC_CS2103T + "\n\t" + TAG_DESC_TEST, expectedFindCommand);
 
 
         // only name keywords
         expectedFindCommand = new FindCommand(
                 new NameContainsKeywordsPredicate(Arrays.asList("Tutorial", "Midterm")),
-                new TagContainsKeywordsPredicate(new HashSet<>()));
+                new TagContainsKeywordsPredicate(new HashSet<>()),
+                new DeadlineInRangePredicate(null, null));
 
         assertParseSuccess(parser, "Tutorial Midterm", expectedFindCommand);
 
@@ -51,7 +57,8 @@ public class FindCommandParserTest {
         // only tag keywords
         expectedFindCommand = new FindCommand(
                 new NameContainsKeywordsPredicate(Arrays.asList("t/CS2103T", "t/Test")),
-                new TagContainsKeywordsPredicate(new HashSet<>(Arrays.asList("CS2103T", "Test"))));
+                new TagContainsKeywordsPredicate(new HashSet<>(Arrays.asList("CS2103T", "Test"))),
+                new DeadlineInRangePredicate(null, null));
 
         assertParseSuccess(parser, TAG_DESC_CS2103T + TAG_DESC_TEST, expectedFindCommand);
 
@@ -59,7 +66,8 @@ public class FindCommandParserTest {
         // name keywords and empty tag
         expectedFindCommand = new FindCommand(
                 new NameContainsKeywordsPredicate(Arrays.asList("Tutorial", "Midterm", "t/")),
-                new TagContainsKeywordsPredicate(new HashSet<>()));
+                new TagContainsKeywordsPredicate(new HashSet<>()),
+                new DeadlineInRangePredicate(null, null));
 
         assertParseSuccess(parser, "Tutorial Midterm t/ ", expectedFindCommand);
     }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -31,31 +32,31 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // both name and tag keywords specified
         FindCommand expectedFindCommand = new FindCommand(
-                new NameContainsKeywordsPredicate(Arrays.asList("Tutorial", "Midterm", "t/CS2103T", "t/Test")),
+                new NameContainsKeywordsPredicate(Set.of("Tutorial", "Midterm")),
                 new TagContainsKeywordsPredicate(new HashSet<>(Arrays.asList("CS2103T", "Test"))),
                 new DeadlineInRangePredicate(null, null));
 
         // name and tag keywords specified, no leading and trailing whitespaces
-        assertParseSuccess(parser, PREFIX_NAME + " Tutorial " + PREFIX_NAME + " Midterm"
+        assertParseSuccess(parser, " " + PREFIX_NAME + " Tutorial " + PREFIX_NAME + " Midterm"
                 + TAG_DESC_CS2103T + TAG_DESC_TEST, expectedFindCommand);
 
         // name and tag keywords specified, multiple whitespaces between keywords
-        assertParseSuccess(parser, PREFIX_NAME + " \n Tutorial \n" + PREFIX_NAME + " \t Midterm \t"
+        assertParseSuccess(parser, " " + PREFIX_NAME + " \n Tutorial \n" + PREFIX_NAME + " \t Midterm \t"
                 + TAG_DESC_CS2103T + "\n\t" + TAG_DESC_TEST, expectedFindCommand);
 
 
         // only name keywords
         expectedFindCommand = new FindCommand(
-                new NameContainsKeywordsPredicate(Arrays.asList("Tutorial", "Midterm")),
+                new NameContainsKeywordsPredicate(Set.of("Tutorial", "Midterm")),
                 new TagContainsKeywordsPredicate(new HashSet<>()),
                 new DeadlineInRangePredicate(null, null));
 
-        assertParseSuccess(parser, "Tutorial Midterm", expectedFindCommand);
+        assertParseSuccess(parser, " n/Tutorial n/Midterm", expectedFindCommand);
 
 
         // only tag keywords
         expectedFindCommand = new FindCommand(
-                new NameContainsKeywordsPredicate(Arrays.asList("t/CS2103T", "t/Test")),
+                new NameContainsKeywordsPredicate(new HashSet<>()),
                 new TagContainsKeywordsPredicate(new HashSet<>(Arrays.asList("CS2103T", "Test"))),
                 new DeadlineInRangePredicate(null, null));
 
@@ -64,11 +65,11 @@ public class FindCommandParserTest {
 
         // name keywords and empty tag
         expectedFindCommand = new FindCommand(
-                new NameContainsKeywordsPredicate(Arrays.asList("Tutorial", "Midterm", "t/")),
+                new NameContainsKeywordsPredicate(Set.of("Tutorial", "Midterm")),
                 new TagContainsKeywordsPredicate(new HashSet<>()),
                 new DeadlineInRangePredicate(null, null));
 
-        assertParseSuccess(parser, "Tutorial Midterm t/ ", expectedFindCommand);
+        assertParseSuccess(parser, " n/Tutorial n/Midterm", expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/HarmoniaParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/HarmoniaParserTest.java
@@ -88,9 +88,7 @@ public class HarmoniaParserTest {
                 FindCommand.COMMAND_WORD + " "
                         + nameKeywordsWithPrefix.stream().collect(Collectors.joining(" ")) + " "
                         + tagKeywordsWithPrefix.stream().collect(Collectors.joining(" ")));
-        List<String> allKeywords = Stream.concat(nameKeywords.stream(), tagKeywordsWithPrefix.stream())
-                .collect(Collectors.toList());
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(allKeywords),
+        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(new HashSet<>(nameKeywords)),
                 new TagContainsKeywordsPredicate(new HashSet<>(tagKeywords)),
                 new DeadlineInRangePredicate(null, null)), command);
     }

--- a/src/test/java/seedu/address/logic/parser/HarmoniaParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/HarmoniaParserTest.java
@@ -82,7 +82,8 @@ public class HarmoniaParserTest {
         List<String> nameKeywords = Arrays.asList("foo", "bar", "baz");
         List<String> tagKeywords = Arrays.asList("tag1", "tag2");
         List<String> tagKeywordsWithPrefix = tagKeywords.stream().map(k -> PREFIX_TAG + k).collect(Collectors.toList());
-        List<String> nameKeywordsWithPrefix = nameKeywords.stream().map(k -> PREFIX_NAME + k).collect(Collectors.toList());
+        List<String> nameKeywordsWithPrefix = nameKeywords.stream().map(k -> PREFIX_NAME + k)
+                .collect(Collectors.toList());
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " "
                         + nameKeywordsWithPrefix.stream().collect(Collectors.joining(" ")) + " "

--- a/src/test/java/seedu/address/logic/parser/HarmoniaParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/HarmoniaParserTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
@@ -30,6 +31,7 @@ import seedu.address.logic.commands.MarkCommand;
 import seedu.address.logic.commands.UnmarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.TagContainsKeywordsPredicate;
+import seedu.address.model.task.DeadlineInRangePredicate;
 import seedu.address.model.task.NameContainsKeywordsPredicate;
 import seedu.address.model.task.Task;
 import seedu.address.testutil.EditTaskDescriptorBuilder;
@@ -80,16 +82,16 @@ public class HarmoniaParserTest {
         List<String> nameKeywords = Arrays.asList("foo", "bar", "baz");
         List<String> tagKeywords = Arrays.asList("tag1", "tag2");
         List<String> tagKeywordsWithPrefix = tagKeywords.stream().map(k -> PREFIX_TAG + k).collect(Collectors.toList());
-
+        List<String> nameKeywordsWithPrefix = nameKeywords.stream().map(k -> PREFIX_NAME + k).collect(Collectors.toList());
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " "
-                        + nameKeywords.stream().collect(Collectors.joining(" ")) + " "
+                        + nameKeywordsWithPrefix.stream().collect(Collectors.joining(" ")) + " "
                         + tagKeywordsWithPrefix.stream().collect(Collectors.joining(" ")));
-
         List<String> allKeywords = Stream.concat(nameKeywords.stream(), tagKeywordsWithPrefix.stream())
                 .collect(Collectors.toList());
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(allKeywords),
-                new TagContainsKeywordsPredicate(new HashSet<>(tagKeywords))), command);
+                new TagContainsKeywordsPredicate(new HashSet<>(tagKeywords)),
+                new DeadlineInRangePredicate(null, null)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/HarmoniaParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/HarmoniaParserTest.java
@@ -14,7 +14,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -12,6 +12,7 @@ import static seedu.address.testutil.TypicalTasks.CS2107_ASSIGNMENT;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -119,7 +120,7 @@ public class ModelManagerTest {
 
         // different filteredList -> returns false
         String[] keywords = CS2107_ASSIGNMENT.getName().fullName.split("\\s+");
-        modelManager.updateFilteredTaskList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
+        modelManager.updateFilteredTaskList(new NameContainsKeywordsPredicate(Set.of(keywords)));
         assertFalse(modelManager.equals(new ModelManager(taskList, userPrefs)));
 
         // resets modelManager to initial state for upcoming tests

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -11,7 +11,6 @@ import static seedu.address.testutil.TypicalTasks.CS2107_ASSIGNMENT;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/model/tag/TagContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/tag/TagContainsKeywordsPredicateTest.java
@@ -42,8 +42,13 @@ public class TagContainsKeywordsPredicateTest {
 
     @Test
     public void test_tagContainsKeywords_returnsTrue() {
+
+        // Zero keywords
+        TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(new HashSet<>());
+
+        assertTrue(predicate.test(new TaskBuilder().withTags("CS3240").build()));
         // One keyword
-        TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(
+        predicate = new TagContainsKeywordsPredicate(
                 Collections.singleton("CS2103T"));
         assertTrue(predicate.test(new TaskBuilder().withTags("CS2103T").build()));
 
@@ -62,12 +67,9 @@ public class TagContainsKeywordsPredicateTest {
 
     @Test
     public void test_tagDoesNotContainKeywords_returnsFalse() {
-        // Zero keywords
-        TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(new HashSet<>());
-        assertFalse(predicate.test(new TaskBuilder().withTags("CS3240").build()));
 
         // Non-matching keyword
-        predicate = new TagContainsKeywordsPredicate(Collections.singleton("CS3240"));
+        TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(Collections.singleton("CS3240"));
         assertFalse(predicate.test(new TaskBuilder().withTags("CS2103T", "Tutorial").build()));
 
         // Keywords match name, description, completion status and deadline, but does not match tag

--- a/src/test/java/seedu/address/model/task/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/task/NameContainsKeywordsPredicateTest.java
@@ -41,8 +41,13 @@ public class NameContainsKeywordsPredicateTest {
 
     @Test
     public void test_nameContainsKeywords_returnsTrue() {
+
+        // Zero keywords
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.emptyList());
+        assertTrue(predicate.test(new TaskBuilder().withName("CS3240").build()));
+
         // One keyword
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(
+        predicate = new NameContainsKeywordsPredicate(
                 Collections.singletonList("CS2103T"));
         assertTrue(predicate.test(new TaskBuilder().withName("CS2103T tutorial").build()));
 
@@ -61,12 +66,9 @@ public class NameContainsKeywordsPredicateTest {
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
-        // Zero keywords
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.emptyList());
-        assertFalse(predicate.test(new TaskBuilder().withName("CS3240").build()));
 
         // Non-matching keyword
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("CS3240"));
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("CS3240"));
         assertFalse(predicate.test(new TaskBuilder().withName("CS2103T Tutorial").build()));
 
         // Keywords match description, completion status, deadline and tags, but does not match name

--- a/src/test/java/seedu/address/model/task/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/task/NameContainsKeywordsPredicateTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -15,18 +16,18 @@ public class NameContainsKeywordsPredicateTest {
 
     @Test
     public void equals() {
-        List<String> firstPredicateKeywordList = Collections.singletonList("first");
-        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+        Set<String> firstPredicateKeywordSet = Collections.singleton("first");
+        Set<String> secondPredicateKeywordSet = Set.of("first", "second");
 
-        NameContainsKeywordsPredicate firstPredicate = new NameContainsKeywordsPredicate(firstPredicateKeywordList);
-        NameContainsKeywordsPredicate secondPredicate = new NameContainsKeywordsPredicate(secondPredicateKeywordList);
+        NameContainsKeywordsPredicate firstPredicate = new NameContainsKeywordsPredicate(firstPredicateKeywordSet);
+        NameContainsKeywordsPredicate secondPredicate = new NameContainsKeywordsPredicate(secondPredicateKeywordSet);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
         NameContainsKeywordsPredicate firstPredicateCopy =
-                new NameContainsKeywordsPredicate(firstPredicateKeywordList);
+                new NameContainsKeywordsPredicate(firstPredicateKeywordSet);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -43,24 +44,24 @@ public class NameContainsKeywordsPredicateTest {
     public void test_nameContainsKeywords_returnsTrue() {
 
         // Zero keywords
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.emptyList());
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.emptySet());
         assertTrue(predicate.test(new TaskBuilder().withName("CS3240").build()));
 
         // One keyword
         predicate = new NameContainsKeywordsPredicate(
-                Collections.singletonList("CS2103T"));
+                Collections.singleton("CS2103T"));
         assertTrue(predicate.test(new TaskBuilder().withName("CS2103T tutorial").build()));
 
         // Multiple keywords
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("CS2103T", "Tutorial"));
+        predicate = new NameContainsKeywordsPredicate(Set.of("CS2103T", "Tutorial"));
         assertTrue(predicate.test(new TaskBuilder().withName("CS2103T Tutorial").build()));
 
         // Only one matching keyword
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("CS2103T", "CS3240"));
+        predicate = new NameContainsKeywordsPredicate(Set.of("CS2103T", "CS3240"));
         assertTrue(predicate.test(new TaskBuilder().withName("CS3240 Finals").build()));
 
         // Mixed-case keywords
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("TutoriaL", "cs3240"));
+        predicate = new NameContainsKeywordsPredicate(Set.of("TutoriaL", "cs3240"));
         assertTrue(predicate.test(new TaskBuilder().withName("CS3240 tutorial").build()));
     }
 
@@ -68,12 +69,11 @@ public class NameContainsKeywordsPredicateTest {
     public void test_nameDoesNotContainKeywords_returnsFalse() {
 
         // Non-matching keyword
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("CS3240"));
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Set.of("CS3240"));
         assertFalse(predicate.test(new TaskBuilder().withName("CS2103T Tutorial").build()));
 
         // Keywords match description, completion status, deadline and tags, but does not match name
-        predicate = new NameContainsKeywordsPredicate(Arrays
-                .asList("G1", "true", "2022-10-22", "CS2103T"));
+        predicate = new NameContainsKeywordsPredicate(Set.of("G1", "true", "2022-10-22", "CS2103T"));
         assertFalse(predicate.test(new TaskBuilder()
                 .withName("Complete Tutorial")
                 .withDescription("Finish 3 parts of G1")

--- a/src/test/java/seedu/address/model/task/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/task/NameContainsKeywordsPredicateTest.java
@@ -3,9 +3,7 @@ package seedu.address.model.task;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Summary of changes:

- Added a new predicate `DeadlineInRangePredicate` for checking whether a deadline falls in a specific range.
- Modified Deadine.java to make it comparable.
- Modified FindCommandParser.java such that it accepts different flags. Now the keywords of the name are prefixed with `n/`. Now it also supports find by start date and/or end date.
- Modified FindCommand.java such that it accepts one more predicate. Now only the tasks that falls within the specified range (if specified) will be displayed.
- Modified ParserUtil.java such that it can parse keywords (single words).
- Some other minor bug fixes. 
- Modified test files.

However, some of the test cases doesn't work now. Will try to fix and update this PR soon. (Resolved)