### PR TITLE
Add option to open user guide url when viewing help 

### DIFF
--- a/src/main/java/seedu/address/ui/ErrorWindow.java
+++ b/src/main/java/seedu/address/ui/ErrorWindow.java
@@ -1,0 +1,87 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
+import seedu.address.commons.core.LogsCenter;
+
+/**
+ * Controller for an error page
+ */
+public class ErrorWindow extends UiPart<Stage> {
+
+    private static final Logger logger = LogsCenter.getLogger(ErrorWindow.class);
+    private static final String FXML = "ErrorWindow.fxml";
+
+    private static String message;
+
+    @FXML
+    private Label errorMessage;
+
+    /**
+     * Creates a new ErrorWindow.
+     *
+     * @param root Stage to use as the root of the ErrorWindow.
+     * @param message Error message to be shown in ErrorWindow.
+     */
+    public ErrorWindow(Stage root, String message) {
+        super(FXML, root);
+        errorMessage.setText(message);
+    }
+
+    /**
+     * Creates a new ErrorWindow.
+     *
+     * @param message Error message to be shown in ErrorWindow.
+     */
+    public ErrorWindow(String message) {
+        this(new Stage(), message);
+    }
+
+    /**
+     * Shows the error window.
+     * @throws IllegalStateException
+     * <ul>
+     *     <li>
+     *         if this method is called on a thread other than the JavaFX Application Thread.
+     *     </li>
+     *     <li>
+     *         if this method is called during animation or layout processing.
+     *     </li>
+     *     <li>
+     *         if this method is called on the primary stage.
+     *     </li>
+     *     <li>
+     *         if {@code dialogStage} is already showing.
+     *     </li>
+     * </ul>
+     */
+    public void show() {
+        logger.fine("Showing error window of the application.");
+        getRoot().show();
+        getRoot().centerOnScreen();
+    }
+
+    /**
+     * Returns true if the error window is currently being shown.
+     */
+    public boolean isShowing() {
+        return getRoot().isShowing();
+    }
+
+    /**
+     * Hides the error window.
+     */
+    public void hide() {
+        getRoot().hide();
+    }
+
+    /**
+     * Focuses on the error window.
+     */
+    public void focus() {
+        getRoot().requestFocus();
+    }
+}

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -1,6 +1,6 @@
 package seedu.address.ui;
 
-import java.awt.*;
+import java.awt.Desktop;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -21,9 +21,12 @@ public class HelpWindow extends UiPart<Stage> {
 
     public static final String USERGUIDE_URL = "https://ay2122s2-cs2103t-t09-1.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
+    public static final String URL_ERROR_MESSAGE = "Unable to open URL to user guide using default browser.";
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
+
+    private static ErrorWindow errorWindow;
 
     @FXML
     private Button copyButton;
@@ -42,6 +45,7 @@ public class HelpWindow extends UiPart<Stage> {
     public HelpWindow(Stage root) {
         super(FXML, root);
         helpMessage.setText(HELP_MESSAGE);
+        errorWindow = new ErrorWindow(URL_ERROR_MESSAGE);
     }
 
     /**
@@ -86,6 +90,7 @@ public class HelpWindow extends UiPart<Stage> {
      * Hides the help window.
      */
     public void hide() {
+        errorWindow.hide();
         getRoot().hide();
     }
 
@@ -94,6 +99,17 @@ public class HelpWindow extends UiPart<Stage> {
      */
     public void focus() {
         getRoot().requestFocus();
+    }
+
+    /**
+     * Opens the error window or focuses on it if it's already opened.
+     */
+    public void handleError() {
+        if (!errorWindow.isShowing()) {
+            errorWindow.show();
+        } else {
+            errorWindow.focus();
+        }
     }
 
     /**
@@ -118,6 +134,7 @@ public class HelpWindow extends UiPart<Stage> {
             desktop.browse(new URI(USERGUIDE_URL));
         } catch (URISyntaxException | IOException e) {
             logger.info("Error opening URL: " + e.getMessage());
+            handleError();
         }
     }
 }

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -1,5 +1,9 @@
 package seedu.address.ui;
 
+import java.awt.*;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
@@ -15,7 +19,7 @@ import seedu.address.commons.core.LogsCenter;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
+    public static final String USERGUIDE_URL = "https://ay2122s2-cs2103t-t09-1.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
@@ -23,6 +27,9 @@ public class HelpWindow extends UiPart<Stage> {
 
     @FXML
     private Button copyButton;
+
+    @FXML
+    private Button openButton;
 
     @FXML
     private Label helpMessage;
@@ -98,5 +105,19 @@ public class HelpWindow extends UiPart<Stage> {
         final ClipboardContent url = new ClipboardContent();
         url.putString(USERGUIDE_URL);
         clipboard.setContent(url);
+    }
+
+    /**
+     * Opens the URL to the user guide using the default browser.
+     */
+    @FXML
+    private void openUrl() {
+        try {
+            logger.info("Opening URL to user guide using default browser");
+            Desktop desktop = java.awt.Desktop.getDesktop();
+            desktop.browse(new URI(USERGUIDE_URL));
+        } catch (URISyntaxException | IOException e) {
+            logger.info("Error opening URL: " + e.getMessage());
+        }
     }
 }

--- a/src/main/resources/view/ErrorWindow.css
+++ b/src/main/resources/view/ErrorWindow.css
@@ -1,0 +1,7 @@
+#errorMessage {
+    -fx-text-fill: white;
+}
+
+#errorMessageContainer {
+    -fx-background-color: derive(#1d1d1d, 20%);
+}

--- a/src/main/resources/view/ErrorWindow.fxml
+++ b/src/main/resources/view/ErrorWindow.fxml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.net.URL?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.Scene?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.image.Image?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.stage.Stage?>
+
+<fx:root resizable="false" title="Error" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+  <icons>
+    <Image url="@/images/info_icon.png" />
+  </icons>
+  <scene>
+    <Scene>
+      <stylesheets>
+        <URL value="@ErrorWindow.css" />
+      </stylesheets>
+      <HBox alignment="CENTER" fx:id="errorMessageContainer">
+        <children>
+          <Label fx:id="errorMessage" text="Label">
+            <HBox.margin>
+              <Insets right="5.0" />
+            </HBox.margin>
+          </Label>
+        </children>
+        <opaqueInsets>
+          <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
+        </opaqueInsets>
+        <padding>
+          <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
+        </padding>
+      </HBox>
+    </Scene>
+  </scene>
+</fx:root>

--- a/src/main/resources/view/HelpWindow.css
+++ b/src/main/resources/view/HelpWindow.css
@@ -1,16 +1,16 @@
-#copyButton, #helpMessage {
+#copyButton, #openButton, #helpMessage {
     -fx-text-fill: white;
 }
 
-#copyButton {
+#copyButton, #openButton {
     -fx-background-color: dimgray;
 }
 
-#copyButton:hover {
+#copyButton:hover, #openButton:hover {
     -fx-background-color: gray;
 }
 
-#copyButton:armed {
+#copyButton:armed, #openButton:armed {
     -fx-background-color: darkgray;
 }
 

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -31,6 +31,11 @@
               <Insets left="5.0" />
             </HBox.margin>
           </Button>
+          <Button fx:id="openButton" mnemonicParsing="false" onAction="#openUrl" text="Open URL">
+            <HBox.margin>
+              <Insets left="5.0" />
+            </HBox.margin>
+          </Button>
         </children>
         <opaqueInsets>
           <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />


### PR DESCRIPTION
Summary of changes:
- Update `USERGUIDE_URL` with link to Harmonia's user guide
- Add option to open url to user guide (users now have the option to either copy or open url using their default browser)
- Create `ErrorWindow`, such that it can be called to inform user of error message if there is an error in opening url