### PR TITLE
Fix TOC formatting, return to top anchors and typography segment

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -11,11 +11,11 @@ Harmonia is a **desktop app for managing tasks related to your academic life, op
 <br>   1.1. [Purpose](#11-purpose)
 <br>   1.2. [How to use this guide](#12-how-to-use-this-guide)
 <br>   1.3. [Typography](#13-typography)
-<br>   __1.3.1. [User Input](#131-user-input)
-<br>   __1.3.2. [User Input](#132-keyboard-input)
+<br>   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1.3.1. [User Input](#131-user-input)
+<br>   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1.3.2. [User Input](#132-keyboard-input)
 <br>   1.4. [Special Sybols](#14-special-symbols)
-<br>   __1.4.1. [Note](#141-note)
-<br>   __1.4.2. [Warning](#142-warning)
+<br>   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1.4.1. [Note](#141-note)
+<br>   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1.4.2. [Warning](#142-warning)
 <br>   1.5. [Graphical User Interface (GUI)](#15-graphical-user-interface-gui)
 2. [Getting Started](#2-getting-started)
 3. [Features](#3-features)
@@ -40,16 +40,16 @@ Harmonia is a **desktop app for managing tasks related to your academic life, op
 This user guide aims to teach you how to use Harmonia to systematically organize your student life. It walks you through all the commands Harmonia has and examples on how to use them. By the end of the guide, you should have a better understanding on how to use Harmonia to help you organise your life.
 
 ### 1.2 How to use this guide
-This guide is designed to be read from top to bottom. At the same time, this guide provides ease of navigation, where you can quickly access the segment you are looking for. To this end, the table of contents summarizes all the different sections of our user guide, and it links you to the section of the guide which you wish to look at in detail. After each section, there is also a “return to top” link which brings you back to the table of contents quickly.
+This guide is designed to be read from top to bottom. At the same time, this guide provides ease of navigation, where you can quickly access the segment you are looking for. To this end, the table of contents summarizes all the different sections of our user guide, and it links you to the section of the guide which you wish to look at in detail. After each section, there is a [Return to Top](#table-of-contents-toc) link enables you to quickly navigate back to the Table of Contents.
 
 ### 1.3 Typography
 This user guide uses different typography to denote different types of information so that you can easily know if the instruction is actionable.
 
 #### 1.3.1 User Input
-`add n/NAME d/DESCRIPTION dl/DEADLINE p/PRIORITY [t/TAG]…`
+This is an example of text denoted as user input: `add n/NAME d/DESCRIPTION dl/DEADLINE p/PRIORITY [t/TAG]…`
 
 #### 1.3.2 Keyboard Input
-<kbd>↵Enter</kbd>
+This is an example of text denoted as keyboard input: <kbd>↵Enter</kbd>
 
 ### 1.4 Special Symbols
 This user guide denotes information that does not flow as part of the text using special symbols enclosed in a box.
@@ -75,7 +75,7 @@ Figure 1.5 depicts the user interface of Harmonia. The following descriptions ex
   ![Harmonia UI](images/Harmonia.png)
   *Figure 1.5: Harmonia's GUI*
 
-[Return to TOC](#table-of-contents-toc)
+[Return to Top](#table-of-contents-toc)
 
 ## 2. Getting Started
 
@@ -99,7 +99,7 @@ Here are a few example commands you can try:
 - `find n/tp`
   - Finds a task with the name `tp`.
 
-[Return to TOC](#table-of-contents-toc)
+[Return to Top](#table-of-contents-toc)
 
 --------------------------------------------------------------------------------------------------------------------
 ## 3. Features
@@ -132,7 +132,7 @@ Here are a few example commands you can try:
 
 </div>
 
-[Return to TOC](#table-of-contents-toc)
+[Return to Top](#table-of-contents-toc)
 
 ### 3.1 Adding a task: `add`
 Adds a task into Harmonia, with a name, description, deadline, priority, and optionally some tags.
@@ -147,7 +147,7 @@ Example: `add n/CS2103T tp meeting d/read the weekly tasks before the meeting dl
 ![UserGuide-add](images/UserGuide-add.png)
 Figure 3.1: Example of Harmonia after adding a task
 
-[Return to TOC](#table-of-contents-toc)
+[Return to Top](#table-of-contents-toc)
 
 ### 3.2 Listing all tasks: `list`
 
@@ -155,7 +155,7 @@ Shows a list of all the existing tasks in the task list.
 
 Format: `list`
 
-[Return to TOC](#table-of-contents-toc)
+[Return to Top](#table-of-contents-toc)
 
 ### 3.3 [Coming soon] Listing all tags: `list t/`
 
@@ -163,7 +163,7 @@ Lists all existing tags used in the task list.
 
 Format: `list t/`
 
-[Return to TOC](#table-of-contents-toc)
+[Return to Top](#table-of-contents-toc)
 
 ### 3.4 Deleting a task: `delete`
 
@@ -177,7 +177,7 @@ Example: `delete 3` deletes the 3rd task in Harmonia.
 You can key `list` to see the sequence of tasks in the list to check the index of the task you wish to delete.
 </div>
 
-[Return to TOC](#table-of-contents-toc)
+[Return to Top](#table-of-contents-toc)
 
 ### 3.5 Locating a task: `find`
 
@@ -199,7 +199,7 @@ Example: `find n/tp n/CS2103T t/meeting start/2022-03-15 end/2022-03-27`
 You can also search using multiple descriptors (e.g. `find n/book t/CS2103T`) to narrow down your search.
 </div>
 
-[Return to TOC](#table-of-contents-toc)
+[Return to Top](#table-of-contents-toc)
 
 ### 3.6 Marking as complete: `mark`
 
@@ -214,7 +214,7 @@ Example:
 You can key `list` to see the sequence of tasks in the list to check the index of the task you wish to mark.
 </div>
 
-[Return to TOC](#table-of-contents-toc)
+[Return to Top](#table-of-contents-toc)
 
 ### 3.7 Marking as incomplete: `unmark`
 
@@ -229,7 +229,7 @@ Example:
 You can key `list` to see the sequence of tasks in the list to check the index of the task you wish to unmark.
 </div>
 
-[Return to TOC](#table-of-contents-toc)
+[Return to Top](#table-of-contents-toc)
 
 ### 3.8 Editing a task: `edit`
 
@@ -248,7 +248,7 @@ Example:
 You can key `list` to see the sequence of tasks in the list to check the index of the task you wish to edit.
 </div>
 
-[Return to TOC](#table-of-contents-toc)
+[Return to Top](#table-of-contents-toc)
 
 ### 3.9 [Coming soon] Sorting tasks: `sort`
 
@@ -273,7 +273,7 @@ You can use the following abbreviations to sort tasks faster.
 - `desc` in place of `descending`
 </div>
 
-[Return to TOC](#table-of-contents-toc)
+[Return to Top](#table-of-contents-toc)
 
 ### 3.10 Viewing help: `help`
 
@@ -281,7 +281,7 @@ Shows the link to the user guide.
 
 Format: `help`
 
-[Return to TOC](#table-of-contents-toc)
+[Return to Top](#table-of-contents-toc)
 
 ### 3.11 Exiting the program: `exit`
 
@@ -289,13 +289,13 @@ Exits the program.
 
 Format: `exit`
 
-[Return to TOC](#table-of-contents-toc)
+[Return to Top](#table-of-contents-toc)
 
 ### 3.12 Saving the data
 
 Harmonia's data is saved in the hard disk automatically after any command changes the data. There is no need to save manually.
 
-[Return to TOC](#table-of-contents-toc)
+[Return to Top](#table-of-contents-toc)
 
 ### 3.13 Editing the data file
 
@@ -305,7 +305,7 @@ Harmonia's data is saved as JSON file ([Location of Harmonia.jar]/data/harmonia.
 If your changes to the data file makes its format invalid, Harmonia will discard all data and start with an empty data file at the next run.
 </div>
 
-[Return to TOC](#table-of-contents-toc)
+[Return to Top](#table-of-contents-toc)
 
 --------------------------------------------------------------------------------------------------------------------
 ## 4. Command summary
@@ -323,4 +323,4 @@ Action | Format, Examples
 **Help** | `help`
 **Exit** | `exit`
 
-[Return to TOC](#table-of-contents-toc)
+[Return to Top](#table-of-contents-toc)


### PR DESCRIPTION
- Fix Table of Contents sub-header formatting
- Change all "Return to TOC" to "Return to Top"
- Add extra elaboration for Typography segment