### PR TITLE
Support search by description/priority

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,5 +1,9 @@
 package seedu.address.logic.commands;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.function.Predicate;
+
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END;
@@ -12,15 +16,10 @@ import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.tag.TagContainsKeywordsPredicate;
 import seedu.address.model.task.DeadlineInRangePredicate;
-import seedu.address.model.task.Description;
 import seedu.address.model.task.DescriptionContainsKeywordsPredicate;
 import seedu.address.model.task.NameContainsKeywordsPredicate;
 import seedu.address.model.task.PriorityMatchedPredicate;
 import seedu.address.model.task.Task;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.function.Predicate;
 
 /**
  * Finds and lists all tasks in task list whose name or tag contains any of the argument keywords.

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -33,11 +33,11 @@ public class FindCommand extends Command {
             + " and displays them as a list with index numbers.\n"
             + "Parameters (must contain at least one keyword): "
             + "[" + PREFIX_NAME + "NAME_KEYWORD]... "
-            + "[" + PREFIX_TAG + "TAG_KEYWORD]... "
+            + "[" + PREFIX_DESCRIPTION + "DESCRIPTION_KEYWORD]... "
             + "[" + PREFIX_START + "START_DATE] "
             + "[" + PREFIX_END + "END_DATE] "
-            + "[" + PREFIX_DESCRIPTION + "DESCRIPTION_KEYWORD]... "
             + "[" + PREFIX_PRIORITY + "PRIORITY]...\n"
+            + "[" + PREFIX_TAG + "TAG_KEYWORD]... "
             + "Example: " + COMMAND_WORD
             + " n/complete n/review t/CS2105 t/CS3240 t/CS2103T "
             + "start/2022-03-11 end/2022-12-31 d/email p/low p/medium";

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,10 +1,16 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.function.Predicate;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
@@ -14,14 +20,6 @@ import seedu.address.model.task.DescriptionContainsKeywordsPredicate;
 import seedu.address.model.task.NameContainsKeywordsPredicate;
 import seedu.address.model.task.PriorityMatchedPredicate;
 import seedu.address.model.task.Task;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.function.Predicate;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
-
 
 /**
  * Finds and lists all tasks in task list whose name or tag contains any of the argument keywords.

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,5 +1,11 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.tag.TagContainsKeywordsPredicate;
@@ -15,11 +21,7 @@ import java.util.function.Predicate;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_END;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_START;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
 
 /**
  * Finds and lists all tasks in task list whose name or tag contains any of the argument keywords.

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.tag.TagContainsKeywordsPredicate;
@@ -37,7 +36,7 @@ public class FindCommand extends Command {
             + "[" + PREFIX_TAG + "TAG_KEYWORD]... "
             + "[" + PREFIX_START + "START_DATE] "
             + "[" + PREFIX_END + "END_DATE] "
-            + "[" + PREFIX_DESCRIPTION+ "DESCRIPTION_KEYWORD]... "
+            + "[" + PREFIX_DESCRIPTION + "DESCRIPTION_KEYWORD]... "
             + "[" + PREFIX_PRIORITY + "PRIORITY]...\n"
             + "Example: " + COMMAND_WORD
             + " n/complete n/review t/CS2105 t/CS3240 t/CS2103T "

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,13 +1,5 @@
 package seedu.address.logic.commands;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_END;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_START;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.tag.TagContainsKeywordsPredicate;
@@ -20,6 +12,14 @@ import seedu.address.model.task.Task;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.function.Predicate;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 /**
  * Finds and lists all tasks in task list whose name or tag contains any of the argument keywords.
@@ -125,6 +125,7 @@ public class FindCommand extends Command {
      * @param predicates the predicates to be combined
      * @return the combined predicate
      */
+    @SafeVarargs
     private Predicate<Task> interceptPredicates(Predicate<Task>... predicates) {
         return Arrays.stream(predicates).reduce(task -> true, Predicate::and);
     }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,8 +1,10 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -10,7 +12,15 @@ import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.tag.TagContainsKeywordsPredicate;
 import seedu.address.model.task.DeadlineInRangePredicate;
+import seedu.address.model.task.Description;
+import seedu.address.model.task.DescriptionContainsKeywordsPredicate;
 import seedu.address.model.task.NameContainsKeywordsPredicate;
+import seedu.address.model.task.PriorityMatchedPredicate;
+import seedu.address.model.task.Task;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.function.Predicate;
 
 /**
  * Finds and lists all tasks in task list whose name or tag contains any of the argument keywords.
@@ -20,17 +30,18 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all tasks whose names or tags contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers. "
-            + "If a range of date is specified, only the tasks with a deadline that falls within the range "
-            + "will be displayed.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all tasks that satisfy all the criteria given"
+            + " and displays them as a list with index numbers.\n"
             + "Parameters (must contain at least one keyword): "
-            + "[" + PREFIX_NAME + "NAME_KEYWORD] "
-            + "[" + PREFIX_TAG + "TAG_KEYWORD] "
-            + "[" + PREFIX_START + "YYYY-MM-DD] "
-            + "[" + PREFIX_END + "YYYY-MM-DD]\n"
+            + "[" + PREFIX_NAME + "NAME_KEYWORD]... "
+            + "[" + PREFIX_TAG + "TAG_KEYWORD]... "
+            + "[" + PREFIX_START + "START_DATE] "
+            + "[" + PREFIX_END + "END_DATE] "
+            + "[" + PREFIX_DESCRIPTION+ "DESCRIPTION_KEYWORD]... "
+            + "[" + PREFIX_PRIORITY + "PRIORITY]...\n"
             + "Example: " + COMMAND_WORD
-            + " tutorial n/assignment t/test t/CS2103T start/2022-03-23 end/2022-03-28";
+            + " n/complete n/review t/CS2105 t/CS3240 t/CS2103T "
+            + "start/2022-03-11 end/2022-12-31 d/email p/low p/medium";
 
     /** Predicate that tests whether task name contains any given keyword */
     private final NameContainsKeywordsPredicate namePredicate;
@@ -41,8 +52,37 @@ public class FindCommand extends Command {
     /** Predicate that tests whether the deadline of a task is within the given date range */
     private final DeadlineInRangePredicate deadlinePredicate;
 
+    /** Predicate that tests whether the priority of a task matches any of the priorities given */
+    private final PriorityMatchedPredicate priorityPredicate;
+
+    /** Predicate that tests whether the description of a task matches any of the keywords given */
+    private final DescriptionContainsKeywordsPredicate descriptionPredicate;
+
     /**
      * Constructor for FindCommand.
+     *
+     * @param namePredicate predicate that tests whether task name contains any given keywords
+     * @param tagPredicate predicate that tests whether tag contains any given keywords
+     * @param deadlinePredicate predicate that tests whether the deadline is in the range
+     * @param descriptionPredicate predicate that tests whether task description contains any given keywords
+     * @param priorityPredicate predicate that tests whether the priority of a task matches any given priorities
+     */
+    public FindCommand(NameContainsKeywordsPredicate namePredicate,
+                       TagContainsKeywordsPredicate tagPredicate,
+                       DeadlineInRangePredicate deadlinePredicate,
+                       DescriptionContainsKeywordsPredicate descriptionPredicate,
+                       PriorityMatchedPredicate priorityPredicate) {
+
+        this.namePredicate = namePredicate;
+        this.tagPredicate = tagPredicate;
+        this.deadlinePredicate = deadlinePredicate;
+        this.descriptionPredicate = descriptionPredicate;
+        this.priorityPredicate = priorityPredicate;
+    }
+
+    /**
+     * This constructor should be removed after the tests for this class is done.
+     * Currently, many of the tests use this constructor, so it is still included here.
      *
      * @param namePredicate predicate that tests whether task name contains any given keywords
      * @param tagPredicate predicate that tests whether tag contains any given keywords
@@ -55,12 +95,16 @@ public class FindCommand extends Command {
         this.namePredicate = namePredicate;
         this.tagPredicate = tagPredicate;
         this.deadlinePredicate = deadlinePredicate;
+        this.descriptionPredicate = new DescriptionContainsKeywordsPredicate(new HashSet<>());
+        this.priorityPredicate = new PriorityMatchedPredicate(new HashSet<>());
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredTaskList(namePredicate.and(tagPredicate).and(deadlinePredicate));
+        Predicate<Task> combinedPredicate = interceptPredicates(namePredicate, tagPredicate,
+                deadlinePredicate, descriptionPredicate, priorityPredicate);
+        model.updateFilteredTaskList(combinedPredicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_TASKS_LISTED_OVERVIEW, model.getFilteredTaskList().size()));
     }
@@ -71,6 +115,18 @@ public class FindCommand extends Command {
                 || (other instanceof FindCommand // instanceof handles nulls
                 && namePredicate.equals(((FindCommand) other).namePredicate)
                 && tagPredicate.equals(((FindCommand) other).tagPredicate)
-                && deadlinePredicate.equals(((FindCommand) other).deadlinePredicate));
+                && deadlinePredicate.equals(((FindCommand) other).deadlinePredicate)
+                && descriptionPredicate.equals(((FindCommand) other).descriptionPredicate)
+                && priorityPredicate.equals(((FindCommand) other).priorityPredicate));
+    }
+
+    /**
+     * Combines predicates using 'and'.
+     *
+     * @param predicates the predicates to be combined
+     * @return the combined predicate
+     */
+    private Predicate<Task> interceptPredicates(Predicate<Task>... predicates) {
+        return Arrays.stream(predicates).reduce(task -> true, Predicate::and);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,9 +1,5 @@
 package seedu.address.logic.commands;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.function.Predicate;
-
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END;
@@ -11,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
 
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
@@ -20,6 +17,10 @@ import seedu.address.model.task.DescriptionContainsKeywordsPredicate;
 import seedu.address.model.task.NameContainsKeywordsPredicate;
 import seedu.address.model.task.PriorityMatchedPredicate;
 import seedu.address.model.task.Task;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.function.Predicate;
 
 /**
  * Finds and lists all tasks in task list whose name or tag contains any of the argument keywords.

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -27,8 +27,8 @@ import seedu.address.model.task.PriorityMatchedPredicate;
 public class FindCommandParser implements Parser<FindCommand> {
 
     private static final Prefix[] POSSIBLE_PREFIXES = new Prefix[] {
-            PREFIX_NAME, PREFIX_TAG, PREFIX_START,
-            PREFIX_END, PREFIX_DESCRIPTION, PREFIX_PRIORITY
+        PREFIX_NAME, PREFIX_TAG, PREFIX_START,
+        PREFIX_END, PREFIX_DESCRIPTION, PREFIX_PRIORITY
     };
 
     /**

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,8 +1,10 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -14,12 +16,20 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.TagContainsKeywordsPredicate;
 import seedu.address.model.task.Deadline;
 import seedu.address.model.task.DeadlineInRangePredicate;
+import seedu.address.model.task.DescriptionContainsKeywordsPredicate;
 import seedu.address.model.task.NameContainsKeywordsPredicate;
+import seedu.address.model.task.Priority;
+import seedu.address.model.task.PriorityMatchedPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
  */
 public class FindCommandParser implements Parser<FindCommand> {
+
+    private static final Prefix[] POSSIBLE_PREFIXES = new Prefix[] {
+            PREFIX_NAME, PREFIX_TAG, PREFIX_START,
+            PREFIX_END, PREFIX_DESCRIPTION, PREFIX_PRIORITY
+    };
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
@@ -28,16 +38,18 @@ public class FindCommandParser implements Parser<FindCommand> {
      */
     public FindCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TAG, PREFIX_START,
-                        PREFIX_END);
+                ArgumentTokenizer.tokenize(args, POSSIBLE_PREFIXES);
 
-        if (!anyPrefixPresent(argMultimap, PREFIX_NAME, PREFIX_TAG, PREFIX_START, PREFIX_END)
+        if (!anyPrefixPresent(argMultimap, POSSIBLE_PREFIXES)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
         Set<String> nameKeywords = ParserUtil.parseKeywords(argMultimap.getAllValues(PREFIX_NAME));
         Set<String> tagKeywords = ParserUtil.parseKeywords(argMultimap.getAllValues(PREFIX_TAG));
+        Set<String> descriptionKeywords = ParserUtil.parseKeywords(argMultimap.getAllValues(PREFIX_DESCRIPTION));
+        Set<Priority> prioritySet = ParserUtil.parsePriorities(argMultimap.getAllValues(PREFIX_PRIORITY));
+
         Deadline startDate = null;
         Deadline endDate = null;
 
@@ -51,7 +63,9 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         return new FindCommand(new NameContainsKeywordsPredicate(nameKeywords),
                 new TagContainsKeywordsPredicate(tagKeywords),
-                new DeadlineInRangePredicate(startDate, endDate));
+                new DeadlineInRangePredicate(startDate, endDate),
+                new DescriptionContainsKeywordsPredicate(descriptionKeywords),
+                new PriorityMatchedPredicate(prioritySet));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -111,6 +111,18 @@ public class ParserUtil {
     }
 
     /**
+     * Parses {@code Collection<String> priorities} into a {@code Set<Priority>}.
+     */
+    public static Set<Priority> parsePriorities(Collection<String> priorities) throws ParseException {
+        requireNonNull(priorities);
+        final Set<Priority> prioritySet = new HashSet<>();
+        for (String priority : priorities) {
+            prioritySet.add(parsePriority(priority));
+        }
+        return prioritySet;
+    }
+
+    /**
      * Parses a {@code String deadline} into a {@code Deadline}.
      * Leading and trailing whitespaces will be trimmed.
      *

--- a/src/main/java/seedu/address/model/task/DescriptionContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/task/DescriptionContainsKeywordsPredicate.java
@@ -1,10 +1,10 @@
 package seedu.address.model.task;
 
-import seedu.address.commons.util.StringUtil;
-
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
 
 /**
  * Tests that a {@code Task}'s {@code Description} matches any of the keywords given.

--- a/src/main/java/seedu/address/model/task/DescriptionContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/task/DescriptionContainsKeywordsPredicate.java
@@ -1,0 +1,35 @@
+package seedu.address.model.task;
+
+import seedu.address.commons.util.StringUtil;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Task}'s {@code Description} matches any of the keywords given.
+ */
+public class DescriptionContainsKeywordsPredicate implements Predicate<Task> {
+
+    private final Set<String> keywords;
+
+    public DescriptionContainsKeywordsPredicate(Set<String> keywords) {
+        this.keywords = new HashSet<>(keywords);
+    }
+
+    @Override
+    public boolean test(Task task) {
+        if (keywords.size() == 0) {
+            return true;
+        }
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(task.getDescription().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DescriptionContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((DescriptionContainsKeywordsPredicate) other).keywords)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/task/PriorityMatchedPredicate.java
+++ b/src/main/java/seedu/address/model/task/PriorityMatchedPredicate.java
@@ -1,0 +1,32 @@
+package seedu.address.model.task;
+
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Task}'s {@code Priority} matches any of the priorities given.
+ */
+public class PriorityMatchedPredicate implements Predicate<Task> {
+
+    private final Set<Priority> prioritySet;
+
+    public PriorityMatchedPredicate(Set<Priority> prioritySet) {
+        this.prioritySet = prioritySet;
+    }
+
+    @Override
+    public boolean test(Task task) {
+        if (prioritySet.size() == 0) {
+            return true;
+        }
+
+        return prioritySet.stream().anyMatch(priority -> priority.equals(task.getPriority()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PriorityMatchedPredicate // instanceof handles nulls
+                && prioritySet.equals(((PriorityMatchedPredicate) other).prioritySet)); // state check
+    }
+}


### PR DESCRIPTION
Summary of changes:

1. Update FindCommand.java such that it checks 5 predicates
2. Update FindCommandParser.java such that it parses the new parameters `d/` and `p/`
3. Add method parsePriorities to support parsing multiple priorities into a set
4. Add DescriptionContainsKeywordsPredicate.java and PriorityMatchedPredicate.java to support the new functionalities.

Notes:

1. Currently in FindCommand.java, the constructor with 3 predicates is preserved, since many of the test cases use this constructor. After the tests are updated in the next iteration, this constructor should be removed.
2. Currently, there's a small problem with matching keywords in descriptions. Since non-alphanumeric characters, e.g. quotation marks, commas, and periods are allowed in description, we can't simply split the description using whitespace when we are finding the match. I'm still thinking about how to do this and will update again.
3. The tests are not modified at all.