### PR TITLE
Enhance keyword matching

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -12,6 +12,17 @@ import java.util.Arrays;
  */
 public class StringUtil {
 
+    public static final String EMPTY_KEYWORD_MESSAGE = "A keyword can't be empty!";
+    public static final String INVALID_KEYWORD_MESSAGE = "Only alphanumeric characters (letters and digits) are"
+            + " allowed in a keyword, and a keyword should be no longer than 63 characters.";
+
+    /*
+     * The first character of the name must not be a whitespace,
+     * and only alphanumeric characters are allowed.
+     * The maximum number of characters allowed is 63.
+     */
+    private static final String KEYWORD_VALIDATION_REGEX = "\\p{Alnum}{1,63}";
+
     /**
      * Returns true if the {@code sentence} contains the {@code word}.
      *   Ignores case, but a full word match is required.
@@ -37,6 +48,42 @@ public class StringUtil {
         return Arrays.stream(wordsInPreppedSentence)
                 .anyMatch(preppedWord::equalsIgnoreCase);
     }
+
+    /**
+     * Returns true if the {@code sentence} contains the {@code word}.
+     *   Ignores case and punctuations, but a full match is required. However, if a word is separated by punctuation(s),
+     *   it is split by the punctuations.
+     *   <br>examples:<pre>
+     *       containsWordIgnorePunctuationAndCase("ABc def", "abc") == true
+     *       containsWordIgnorePunctuationAndCase("ABc, def", "abc") == true
+     *       containsWordIgnorePunctuationAndCase("ABc,def", "abc") == true
+     *       containsWordIgnorePunctuationAndCase("ABc-def", "abcdef") == false // "ABc-def" is split into two words
+     *       containsWordIgnorePunctuationAndCase("ABc def", "AB") == false //not a full word match
+     *       </pre>
+     * @param sentence cannot be null
+     * @param word cannot be null, cannot be empty, must be a single word without punctuation(s)
+     */
+    public static boolean containsWordIgnorePunctuationAndCase(String sentence, String word) {
+        requireNonNull(sentence);
+        validateKeyword(word);
+
+        String preppedWord = word.trim();
+        return Arrays.stream(sentence.split("[^\\p{Alnum}]+")).anyMatch(preppedWord::equalsIgnoreCase);
+    }
+
+    /**
+     * Validates a keyword. A keyword should be alphanumeric, and its length should be 1 to 63.
+     *
+     * @param keyword the keyword to be checked
+     */
+    private static void validateKeyword(String keyword) {
+        requireNonNull(keyword);
+        String trimmedKeyword = keyword.trim();
+
+        // If the regex is matched, it ensures that there's only one keyword.
+        checkArgument(trimmedKeyword.matches(KEYWORD_VALIDATION_REGEX), INVALID_KEYWORD_MESSAGE);
+    }
+
 
     /**
      * Returns a detailed message of the t, including the stack trace.

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.StringUtil.EMPTY_KEYWORD_MESSAGE;
+import static seedu.address.commons.util.StringUtil.INVALID_KEYWORD_MESSAGE;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -145,13 +147,17 @@ public class ParserUtil {
         final Set<String> keywordSet = new HashSet<>();
         for (String keyword : keywords) {
             if (keyword.isEmpty()) {
-                throw new ParseException("A keyword can't be empty!");
+                throw new ParseException(EMPTY_KEYWORD_MESSAGE);
             }
-            if (keyword.split("\\s+").length > 1) {
-                throw new ParseException("A keyword can't contain any whitespace!");
+            if (!isValidKeyword(keyword)) {
+                throw new ParseException(INVALID_KEYWORD_MESSAGE);
             }
             keywordSet.add(keyword);
         }
         return keywordSet;
+    }
+
+    private static boolean isValidKeyword(String keyword) {
+        return keyword.matches("\\p{Alnum}{1,63}");
     }
 }

--- a/src/main/java/seedu/address/model/task/DescriptionContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/task/DescriptionContainsKeywordsPredicate.java
@@ -23,7 +23,8 @@ public class DescriptionContainsKeywordsPredicate implements Predicate<Task> {
             return true;
         }
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(task.getDescription().value, keyword));
+                .anyMatch(keyword -> StringUtil
+                        .containsWordIgnorePunctuationAndCase(task.getDescription().value, keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/task/NameContainsKeywordsPredicate.java
@@ -22,7 +22,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Task> {
             return true;
         }
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(task.getName().fullName, keyword));
+                .anyMatch(keyword -> StringUtil.containsWordIgnorePunctuationAndCase(task.getName().fullName, keyword));
     }
 
     @Override

--- a/src/test/java/seedu/address/model/task/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/task/NameContainsKeywordsPredicateTest.java
@@ -71,7 +71,7 @@ public class NameContainsKeywordsPredicateTest {
         assertFalse(predicate.test(new TaskBuilder().withName("CS2103T Tutorial").build()));
 
         // Keywords match description, completion status, deadline and tags, but does not match name
-        predicate = new NameContainsKeywordsPredicate(Set.of("G1", "true", "2022-10-22", "CS2103T"));
+        predicate = new NameContainsKeywordsPredicate(Set.of("G1", "true", "2022", "CS2103T"));
         assertFalse(predicate.test(new TaskBuilder()
                 .withName("Complete Tutorial")
                 .withDescription("Finish 3 parts of G1")


### PR DESCRIPTION
Previously, Harmonia looks for exact match using
StringUtil::containsKeywordIgnoreCase.

However, this is not user friendly, as Harmonia won't ignore
punctuations contained in the word, e.g. `emailsEnhance keyword matching

Previously, Harmonia looks for exact match using
StringUtil::containsKeywordIgnoreCase.

However, this is not user friendly, as Harmonia won't ignore
punctuations contained in the word, e.g. `emails,`. Hence a search of
`email` will return false.

Currently, a new method StringUtil::containsWordIgnorePunctuationAndCase
is implemented, to relax the keyword searching criteria. This method
splits the sentence using any non-alphanumeric character(s), and
enforces the user to enter a alphanumeric keyword.

The test() in DescriptonContainsKeywordsPredicate.java and
NameContainsKeywordsPredicate.java are using this method currently.
ParserUtil::parseKeywords also enforces that the user enters an
alphanumeric keyword.

In the next iteration, keywords should be abstracted out into a class `Keyword`, to make it more OOP and scalable. An issue will be opened once this PR is merged.

Resolves #205