### PR TITLE
Fix bug on unmark command and make sort by name case insensitive

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -91,7 +91,6 @@ public class MarkCommand extends Command {
                 model.strictSetTask(taskToMark, markedTask);
             }
         }
-        model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
         return result(markedTasks, markedTasksIndexes, alreadyMarkedIndexes, outOfBoundsIndexes);
     }
 

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TASKS;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
@@ -89,7 +89,6 @@ public class UnmarkCommand extends Command {
                 unmarkedTasksIndexes.add(index);
 
                 model.strictSetTask(taskToUnmark, unmarkedTask);
-                model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
             }
         }
         return result(unmarkedTasks, unmarkedTasksIndexes, alreadyUnmarkedIndexes, outOfBoundsIndexes);

--- a/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TASKS;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/seedu/address/logic/commands/sort/ComparatorFactory.java
+++ b/src/main/java/seedu/address/logic/commands/sort/ComparatorFactory.java
@@ -19,7 +19,7 @@ public class ComparatorFactory {
     private static Comparator<Task> createComparatorOnSortKey(SortKey sortKey) {
         switch (sortKey) {
         case NAME:
-            return Comparator.comparing(Task::getName);
+            return Comparator.comparing(Task::getName).thenComparing(Task::getDeadline);
 
         case DEADLINE:
             return Comparator.comparing(Task::getDeadline).thenComparing(Task::getName);

--- a/src/main/java/seedu/address/model/task/Name.java
+++ b/src/main/java/seedu/address/model/task/Name.java
@@ -59,6 +59,7 @@ public class Name implements Comparable<Name> {
 
     @Override
     public int compareTo(Name n) {
-        return this.fullName.compareTo(n.fullName);
+        return this.fullName.toLowerCase()
+                .compareTo(n.fullName.toLowerCase());
     }
 }


### PR DESCRIPTION
Summary of changes:
- Fix bug on `Unmark` command  and preserve filtered list:
  - Update `MarkCommand` and `UnmarkCommand`
- Make sort by `Name` case insensitive and include sorting by `Name` then by `Deadline`:
  - Update `ComparatorFactory` and `Name`

Resolves #259 and #228