### PR TITLE
Fix bugs in messages for deadline & related predicate

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -71,6 +71,10 @@ public class FindCommandParser implements Parser<FindCommand> {
             completionStatus = ParserUtil.parseCompletionStatus(argMultimap.getValue(PREFIX_COMPLETION_STATUS).get());
         }
 
+        if (!DeadlineInRangePredicate.isValidRange(startDate, endDate)) {
+            throw new ParseException(DeadlineInRangePredicate.INVALID_RANGE_MESSAGE);
+        }
+
         return new FindCommand(new NameContainsKeywordsPredicate(nameKeywords),
                 new TagContainsKeywordsPredicate(tagKeywords),
                 new DeadlineInRangePredicate(startDate, endDate),

--- a/src/main/java/seedu/address/model/task/Deadline.java
+++ b/src/main/java/seedu/address/model/task/Deadline.java
@@ -13,7 +13,7 @@ import java.time.format.DateTimeParseException;
 public class Deadline implements Comparable<Deadline> {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Deadlines should be in the format YYYY-MM-DD";
+            "Deadlines should be a valid date, and in the format YYYY-MM-DD";
     static final Deadline MIN_DEADLINE = new Deadline(LocalDate.MIN);
     static final Deadline MAX_DEADLINE = new Deadline(LocalDate.MAX);
 

--- a/src/main/java/seedu/address/model/task/DeadlineInRangePredicate.java
+++ b/src/main/java/seedu/address/model/task/DeadlineInRangePredicate.java
@@ -11,6 +11,8 @@ import java.util.function.Predicate;
  */
 public class DeadlineInRangePredicate implements Predicate<Task> {
 
+    public static final String INVALID_RANGE_MESSAGE = "The start date cannot be later than the end date!";
+
     private final Optional<Deadline> startDate;
     private final Optional<Deadline> endDate;
 
@@ -25,6 +27,21 @@ public class DeadlineInRangePredicate implements Predicate<Task> {
     public DeadlineInRangePredicate(Deadline startDate, Deadline endDate) {
         this.startDate = Optional.ofNullable(startDate);
         this.endDate = Optional.ofNullable(endDate);
+    }
+
+    /**
+     * Checks whether a range of deadline is valid.
+     *
+     * @param startDate the lower bound of deadline
+     * @param endDate the upper bound of deadline
+     * @return true if {@code startDate} is not later than {@code endDate}
+     */
+    public static boolean isValidRange(Deadline startDate, Deadline endDate) {
+        if (startDate == null || endDate == null) {
+            // If one of the deadline is missing, then it is always valid.
+            return true;
+        }
+        return startDate.compareTo(endDate) <= 0;
     }
 
     @Override


### PR DESCRIPTION
Summary of Changes:

1. Change the error message displayed for invalid deadline input
2. Add an additional check in FindCommandParser.java such that range with a start date that's later than then end date is no longer allowed.

resolves #230
resolves #257