### PR TITLE
Fix name such that it is case-insensitive

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -112,4 +112,15 @@ public class StringUtil {
             return false;
         }
     }
+
+    /**
+     * Checks whether two strings are the same, ignoring the cases.
+     *
+     * @param s1 the first string to be compared
+     * @param s2 the second string to be compared
+     * @return true if s1 and s2 contain the same value, ignoring the cases
+     */
+    public static boolean isSameStringIgnoreCases(String s1, String s2) {
+        return s1.toLowerCase().equals(s2.toLowerCase());
+    }
 }

--- a/src/main/java/seedu/address/model/task/Name.java
+++ b/src/main/java/seedu/address/model/task/Name.java
@@ -2,6 +2,7 @@ package seedu.address.model.task;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
+import static seedu.address.commons.util.StringUtil.isSameStringIgnoreCases;
 
 /**
  * Represents a Task's name in the task list.
@@ -48,11 +49,19 @@ public class Name implements Comparable<Name> {
         return fullName;
     }
 
+    /**
+     * Checks whether two {@code Name}s are equal.
+     * If two {@code Name}s contain the same {@code String}, ignoring the cases,
+     * they are considered as the same.
+     *
+     * @param other the other {@code Object} to be compared with
+     * @return true if {@code other} is a {@code Name} and has the same {@code String} internally, ignoring the cases
+     */
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Name // instanceof handles nulls
-                && fullName.equals(((Name) other).fullName)); // state check
+                && isSameStringIgnoreCases(this.fullName, ((Name) other).fullName)); // state check
     }
 
     @Override


### PR DESCRIPTION
Summary of changes:

1. Add a method in StringUtil.java to check whether two strings are the same, ignoring the case.
2. Modify the equals() in Name.java, to make name case-insensitive, hence users are not allowed to add tasks with same name, but different cases.

Resolves #251