### PR TITLE
Add tests for delete command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -77,16 +77,15 @@ public class DeleteCommand extends Command {
      * @return a {@code String} of the list of indexes that are passed into the function.
      */
     private String indexesToString(List<Index> indexes) {
-        String str = "" + indexes.get(0).getOneBased();
-        for (int i = 1; i < indexes.size(); i++) {
-            int index = indexes.get(i).getOneBased();
-            if (indexes.size() > 1 && i == indexes.size() - 1) {
-                str += " and " + index;
-            } else {
-                str += ", " + index;
+        StringBuilder str = new StringBuilder();
+        if (indexes.size() > 1) {
+            for (int i = indexes.size() - 1; i >= 1; i--) {
+                str.append(indexes.get(i).getOneBased());
+                str.append(i == 1 ? " and " : ", ");
             }
         }
-        return str;
+        str.append(indexes.get(0).getOneBased());
+        return str.toString();
     }
 
     /**

--- a/src/test/java/seedu/address/AppParametersTest.java
+++ b/src/test/java/seedu/address/AppParametersTest.java
@@ -1,58 +1,58 @@
-//package seedu.address;
-//
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//
-//import java.nio.file.Paths;
-//import java.util.Collections;
-//import java.util.HashMap;
-//import java.util.List;
-//import java.util.Map;
-//
-//import org.junit.jupiter.api.Test;
-//
-//import javafx.application.Application;
-//
-//public class AppParametersTest {
-//
-//    private final ParametersStub parametersStub = new ParametersStub();
-//    private final AppParameters expected = new AppParameters();
-//
-//    @Test
-//    public void parse_validConfigPath_success() {
-//        parametersStub.namedParameters.put("config", "config.json");
-//        expected.setConfigPath(Paths.get("config.json"));
-//        assertEquals(expected, AppParameters.parse(parametersStub));
-//    }
-//
-//    @Test
-//    public void parse_nullConfigPath_success() {
-//        parametersStub.namedParameters.put("config", null);
-//        assertEquals(expected, AppParameters.parse(parametersStub));
-//    }
-//
-//    @Test
-//    public void parse_invalidConfigPath_success() {
-//        parametersStub.namedParameters.put("config", "a\0");
-//        expected.setConfigPath(null);
-//        assertEquals(expected, AppParameters.parse(parametersStub));
-//    }
-//
-//    private static class ParametersStub extends Application.Parameters {
-//        private Map<String, String> namedParameters = new HashMap<>();
-//
-//        @Override
-//        public List<String> getRaw() {
-//            throw new AssertionError("should not be called");
-//        }
-//
-//        @Override
-//        public List<String> getUnnamed() {
-//            throw new AssertionError("should not be called");
-//        }
-//
-//        @Override
-//        public Map<String, String> getNamed() {
-//            return Collections.unmodifiableMap(namedParameters);
-//        }
-//    }
-//}
+package seedu.address;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import javafx.application.Application;
+
+public class AppParametersTest {
+
+    private final ParametersStub parametersStub = new ParametersStub();
+    private final AppParameters expected = new AppParameters();
+
+    @Test
+    public void parse_validConfigPath_success() {
+        parametersStub.namedParameters.put("config", "config.json");
+        expected.setConfigPath(Paths.get("config.json"));
+        assertEquals(expected, AppParameters.parse(parametersStub));
+    }
+
+    @Test
+    public void parse_nullConfigPath_success() {
+        parametersStub.namedParameters.put("config", null);
+        assertEquals(expected, AppParameters.parse(parametersStub));
+    }
+
+    @Test
+    public void parse_invalidConfigPath_success() {
+        parametersStub.namedParameters.put("config", "a\0");
+        expected.setConfigPath(null);
+        assertEquals(expected, AppParameters.parse(parametersStub));
+    }
+
+    private static class ParametersStub extends Application.Parameters {
+        private Map<String, String> namedParameters = new HashMap<>();
+
+        @Override
+        public List<String> getRaw() {
+            throw new AssertionError("should not be called");
+        }
+
+        @Override
+        public List<String> getUnnamed() {
+            throw new AssertionError("should not be called");
+        }
+
+        @Override
+        public Map<String, String> getNamed() {
+            return Collections.unmodifiableMap(namedParameters);
+        }
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -134,4 +134,24 @@ public class CommandTestUtil {
         assertEquals(1, model.getFilteredTaskList().size());
     }
 
+    /**
+     * Updates {@code model}'s filtered list to show the tasks at the 2 given {@code targetIndexes} in the
+     * {@code model}'s task list.
+     */
+    public static void showTasksAtIndexes(Model model, Index targetIndex1, Index targetIndex2) {
+        assertTrue(targetIndex1.getZeroBased() < model.getFilteredTaskList().size());
+        assertTrue(targetIndex2.getZeroBased() < model.getFilteredTaskList().size());
+
+        Task task1 = model.getFilteredTaskList().get(targetIndex1.getZeroBased());
+        String[] splitName1 = task1.getName().fullName.split("\\s+");
+        NameContainsKeywordsPredicate p1 = new NameContainsKeywordsPredicate(Collections.singleton(splitName1[0]));
+
+        Task task2 = model.getFilteredTaskList().get(targetIndex2.getZeroBased());
+        String[] splitName2 = task2.getName().fullName.split("\\s+");
+        NameContainsKeywordsPredicate p2 = new NameContainsKeywordsPredicate(Collections.singleton(splitName2[0]));
+
+        model.updateFilteredTaskList(p1.or(p2));
+        assertEquals(2, model.getFilteredTaskList().size());
+    }
+
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -1,109 +1,255 @@
-//package seedu.address.logic.commands;
-//
-//import static org.junit.jupiter.api.Assertions.assertFalse;
-//import static org.junit.jupiter.api.Assertions.assertTrue;
-//import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-//import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-//import static seedu.address.logic.commands.CommandTestUtil.showTaskAtIndex;
-//import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
-//import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_TASK;
-//import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
-//
-//import org.junit.jupiter.api.Test;
-//
-//import seedu.address.commons.core.Messages;
-//import seedu.address.commons.core.index.Index;
-//import seedu.address.model.Model;
-//import seedu.address.model.ModelManager;
-//import seedu.address.model.UserPrefs;
-//import seedu.address.model.task.Task;
-//
-///**
-// * Contains integration tests (interaction with the Model) and unit tests for
-// * {@code DeleteCommand}.
-// */
-//public class DeleteCommandTest {
-//
-//    private Model model = new ModelManager(getTypicalTaskList(), new UserPrefs());
-//
-//    @Test
-//    public void execute_validIndexUnfilteredList_success() {
-//        Task taskToDelete = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
-//        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_TASK);
-//
-//        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_TASK_SUCCESS, taskToDelete);
-//
-//        ModelManager expectedModel = new ModelManager(model.getTaskList(), new UserPrefs());
-//        expectedModel.deleteTask(taskToDelete);
-//
-//        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
-//    }
-//
-//    @Test
-//    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-//        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
-//        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
-//
-//        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
-//    }
-//
-//    @Test
-//    public void execute_validIndexFilteredList_success() {
-//        showTaskAtIndex(model, INDEX_FIRST_TASK);
-//
-//        Task taskToDelete = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
-//        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_TASK);
-//
-//        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_TASK_SUCCESS, taskToDelete);
-//
-//        Model expectedModel = new ModelManager(model.getTaskList(), new UserPrefs());
-//        expectedModel.deleteTask(taskToDelete);
-//        showNoTask(expectedModel);
-//
-//        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
-//    }
-//
-//    @Test
-//    public void execute_invalidIndexFilteredList_throwsCommandException() {
-//        showTaskAtIndex(model, INDEX_FIRST_TASK);
-//
-//        Index outOfBoundIndex = INDEX_SECOND_TASK;
-//        // ensures that outOfBoundIndex is still in bounds of address book list
-//        assertTrue(outOfBoundIndex.getZeroBased() < model.getTaskList().getTaskList().size());
-//
-//        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
-//
-//        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
-//    }
-//
-//    @Test
-//    public void equals() {
-//        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_TASK);
-//        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_TASK);
-//
-//        // same object -> returns true
-//        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
-//
-//        // same values -> returns true
-//        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_TASK);
-//        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
-//
-//        // different types -> returns false
-//        assertFalse(deleteFirstCommand.equals(1));
-//
-//        // null -> returns false
-//        assertFalse(deleteFirstCommand.equals(null));
-//
-//        // different task -> returns false
-//        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
-//    }
-//
-//    /**
-//     * Updates {@code model}'s filtered list to show no one.
-//     */
-//    private void showNoTask(Model model) {
-//        model.updateFilteredTaskList(p -> false);
-//
-//        assertTrue(model.getFilteredTaskList().isEmpty());
-//    }
-//}
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showTaskAtIndex;
+import static seedu.address.logic.commands.CommandTestUtil.showTasksAtIndexes;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIFTH_TASK;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_TASK;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_TASK;
+import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.task.Task;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code DeleteCommand}.
+ */
+public class DeleteCommandTest {
+
+    private Model model = new ModelManager(getTypicalTaskList(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        List<Index> listOfIndexToDelete = List.of(INDEX_FIRST_TASK);
+        Task taskToDelete = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
+        List<Task> listOfTaskToDelete = List.of(taskToDelete);
+
+        DeleteCommand deleteCommand = new DeleteCommand(listOfIndexToDelete);
+
+        String expectedMessage = getExpectedSuccessMessage(listOfTaskToDelete, listOfIndexToDelete);
+
+        ModelManager expectedModel = new ModelManager(model.getTaskList(), new UserPrefs());
+        expectedModel.deleteTask(taskToDelete);
+
+        System.out.println(expectedMessage);
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_multipleValidIndexUnfilteredList_success() {
+        List<Index> listOfIndexToDelete = Arrays.asList(INDEX_SECOND_TASK, INDEX_FIRST_TASK);
+        Task firstTaskToDelete = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
+        Task secondTaskToDelete = model.getFilteredTaskList().get(INDEX_SECOND_TASK.getZeroBased());
+        List<Task> listOfTaskToDelete = Arrays.asList(secondTaskToDelete, firstTaskToDelete);
+
+        DeleteCommand deleteCommand = new DeleteCommand(listOfIndexToDelete);
+
+        String expectedMessage = getExpectedSuccessMessage(listOfTaskToDelete, listOfIndexToDelete);
+
+        ModelManager expectedModel = new ModelManager(model.getTaskList(), new UserPrefs());
+        expectedModel.deleteTask(secondTaskToDelete);
+        expectedModel.deleteTask(firstTaskToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        List<Index> listOfIndexToDelete = List.of(outOfBoundIndex);
+
+        DeleteCommand deleteCommand = new DeleteCommand(listOfIndexToDelete);
+
+        String expectedMessage = getExpectedErrorMessage(listOfIndexToDelete);
+        assertCommandFailure(deleteCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_multipleInvalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex1 = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        Index outOfBoundIndex2 = Index.fromOneBased(model.getFilteredTaskList().size() + 2);
+        List<Index> listOfOutOfBoundIndex = Arrays.asList(outOfBoundIndex1, outOfBoundIndex2);
+
+        DeleteCommand deleteCommand = new DeleteCommand(listOfOutOfBoundIndex);
+
+        String expectedMessage = getExpectedErrorMessage(listOfOutOfBoundIndex);
+        assertCommandFailure(deleteCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_validAndMultipleInvalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex1 = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        Index outOfBoundIndex2 = Index.fromOneBased(model.getFilteredTaskList().size() + 2);
+        List<Index> listOfOutOfBoundIndex = Arrays.asList(outOfBoundIndex1, outOfBoundIndex2);
+        List<Index> listOfIndexToDelete = Arrays.asList(INDEX_FIRST_TASK, outOfBoundIndex1, outOfBoundIndex2);
+
+        DeleteCommand deleteCommand = new DeleteCommand(listOfIndexToDelete);
+
+        String expectedMessage = getExpectedErrorMessage(listOfOutOfBoundIndex);
+        assertCommandFailure(deleteCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showTaskAtIndex(model, INDEX_FIRST_TASK);
+
+        List<Index> listOfIndexToDelete = List.of(INDEX_FIRST_TASK);
+        Task taskToDelete = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
+        List<Task> listOfTaskToDelete = List.of(taskToDelete);
+
+        DeleteCommand deleteCommand = new DeleteCommand(listOfIndexToDelete);
+
+        String expectedMessage = getExpectedSuccessMessage(listOfTaskToDelete, listOfIndexToDelete);
+
+        Model expectedModel = new ModelManager(model.getTaskList(), new UserPrefs());
+        expectedModel.deleteTask(taskToDelete);
+        showNoTask(expectedModel);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_multipleValidIndexFilteredList_success() {
+        showTasksAtIndexes(model, INDEX_FIRST_TASK, INDEX_SECOND_TASK);
+
+        List<Index> listOfIndexToDelete = Arrays.asList(INDEX_SECOND_TASK, INDEX_FIRST_TASK);
+        Task firstTaskToDelete = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
+        Task secondTaskToDelete = model.getFilteredTaskList().get(INDEX_SECOND_TASK.getZeroBased());
+        List<Task> listOfTaskToDelete = Arrays.asList(secondTaskToDelete, firstTaskToDelete);
+
+        DeleteCommand deleteCommand = new DeleteCommand(listOfIndexToDelete);
+
+        String expectedMessage = getExpectedSuccessMessage(listOfTaskToDelete, listOfIndexToDelete);
+
+        Model expectedModel = new ModelManager(model.getTaskList(), new UserPrefs());
+        expectedModel.deleteTask(firstTaskToDelete);
+        expectedModel.deleteTask(secondTaskToDelete);
+        showNoTask(expectedModel);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showTaskAtIndex(model, INDEX_FIRST_TASK);
+
+        Index outOfBoundIndex = INDEX_SECOND_TASK;
+        // ensures that outOfBoundIndex is still in bounds of task list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getTaskList().getTaskList().size());
+
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(outOfBoundIndex));
+
+        String expectedMessage = getExpectedErrorMessage(List.of(outOfBoundIndex));
+        assertCommandFailure(deleteCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_multipleInvalidIndexFilteredList_throwsCommandException() {
+        showTaskAtIndex(model, INDEX_FIRST_TASK);
+
+        List<Index> listOfOutOfBoundIndex = Arrays.asList(INDEX_SECOND_TASK, INDEX_THIRD_TASK);
+        // ensures that outOfBoundIndexes are still in bounds of task list
+        assertTrue(INDEX_SECOND_TASK.getZeroBased() < model.getTaskList().getTaskList().size());
+        assertTrue(INDEX_THIRD_TASK.getZeroBased() < model.getTaskList().getTaskList().size());
+
+        DeleteCommand deleteCommand = new DeleteCommand(listOfOutOfBoundIndex);
+
+        String expectedMessage = getExpectedErrorMessage(listOfOutOfBoundIndex);
+        assertCommandFailure(deleteCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_validAndMultipleInvalidIndexFilteredList_throwsCommandException() {
+        showTasksAtIndexes(model, INDEX_FIRST_TASK, INDEX_SECOND_TASK);
+
+        List<Index> listOfIndexToDelete = Arrays.asList(INDEX_FIRST_TASK, INDEX_THIRD_TASK, INDEX_FIFTH_TASK);
+        List<Index> listOfOutOfBoundIndex = Arrays.asList(INDEX_THIRD_TASK, INDEX_FIFTH_TASK);
+        // ensures that outOfBoundIndexes are still in bounds of task list
+        assertTrue(INDEX_THIRD_TASK.getZeroBased() < model.getTaskList().getTaskList().size());
+        assertTrue(INDEX_FIFTH_TASK.getZeroBased() < model.getTaskList().getTaskList().size());
+
+        DeleteCommand deleteCommand = new DeleteCommand(listOfIndexToDelete);
+
+        String expectedMessage = getExpectedErrorMessage(listOfOutOfBoundIndex);
+        assertCommandFailure(deleteCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void equals() {
+        DeleteCommand deleteFirstCommand = new DeleteCommand(List.of(INDEX_FIRST_TASK));
+        DeleteCommand deleteSecondCommand = new DeleteCommand(List.of(INDEX_SECOND_TASK));
+
+        // same object -> returns true
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+
+        // same values -> returns true
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(List.of(INDEX_FIRST_TASK));
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteFirstCommand.equals(null));
+
+        // different task -> returns false
+        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no one.
+     */
+    private void showNoTask(Model model) {
+        model.updateFilteredTaskList(p -> false);
+
+        assertTrue(model.getFilteredTaskList().isEmpty());
+    }
+
+    /**
+     * Returns the expected success message.
+     */
+    private String getExpectedSuccessMessage(List<Task> deletedTasks, List<Index> deletedTasksIndexes) {
+        String str = "Successfully Deleted Tasks: \n";
+        for (int i = deletedTasks.size() - 1; i >= 0; i--) {
+            str += deletedTasksIndexes.get(i).getOneBased() + ". " + deletedTasks.get(i) + "\n";
+        }
+        return str;
+    }
+
+    /**
+     * Returns the expected error message.
+     */
+    private String getExpectedErrorMessage(List<Index> outOfBoundsIndexes) {
+        return String.format("Index %s: %s\n", indexesToString(outOfBoundsIndexes),
+                Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Converts a list of indexes to a string.
+     */
+    private String indexesToString(List<Index> indexes) {
+        StringBuilder str = new StringBuilder();
+        str.append(indexes.get(0).getOneBased());
+        if (indexes.size() > 1) {
+            for (int i = 1; i < indexes.size(); i++) {
+                str.append(i == 1 ? " and " : ", ");
+                str.append(indexes.get(i).getOneBased());
+            }
+        }
+        return str.toString();
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,32 +1,42 @@
-//package seedu.address.logic.parser;
-//
-//import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-//import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
-//import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-//import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
-//
-//import org.junit.jupiter.api.Test;
-//
-//import seedu.address.logic.commands.DeleteCommand;
-//
-///**
-// * As we are only doing white-box testing, our test cases do not cover path variations
-// * outside of the DeleteCommand code. For example, inputs "1" and "1 abc" take the
-// * same path through the DeleteCommand, and therefore we test only one of them.
-// * The path variation for those two cases occur inside the ParserUtil, and
-// * therefore should be covered by the ParserUtilTest.
-// */
-//public class DeleteCommandParserTest {
-//
-//    private DeleteCommandParser parser = new DeleteCommandParser();
-//
-//    @Test
-//    public void parse_validArgs_returnsDeleteCommand() {
-//        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_TASK));
-//    }
-//
-//    @Test
-//    public void parse_invalidArgs_throwsParseException() {
-//        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-//    }
-//}
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIFTH_TASK;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_TASK;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.DeleteCommand;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the DeleteCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the DeleteCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class DeleteCommandParserTest {
+
+    private DeleteCommandParser parser = new DeleteCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteCommand() {
+        // only 1 index specified
+        assertParseSuccess(parser, "1", new DeleteCommand(List.of(INDEX_FIRST_TASK)));
+
+        // multiple indexes specified
+        assertParseSuccess(parser, "1 3 5",
+                new DeleteCommand(List.of(INDEX_FIRST_TASK, INDEX_THIRD_TASK, INDEX_FIFTH_TASK)));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -36,7 +36,12 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
+        // not a number
         assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+
+        // not a positive number
+        assertParseFailure(parser, "-1",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
Summary of changes:
1. Add tests for deleting multiple indexes
2. Edit `DeleteCommand#indexesToString` such that it formats indexes in ascending order
3. Uncomment tests in `AppParametersTest`