### PR TITLE
Test for MassOps

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -113,18 +113,16 @@ public class MarkCommand extends Command {
      * @return a {@code String} of the list of indexes that are passed into the function.
      */
     private String indexesToString(List<Index> indexes) {
-        String str = "" + indexes.get(0).getOneBased();
-        for (int i = 1; i < indexes.size(); i++) {
-            int index = indexes.get(i).getOneBased();
-            if (indexes.size() > 1 && i == indexes.size() - 1) {
-                str += " and " + index;
-            } else {
-                str += ", " + index;
+        StringBuilder str = new StringBuilder();
+        if (indexes.size() > 1) {
+            for (int i = indexes.size() - 1; i >= 1; i--) {
+                str.append(indexes.get(i).getOneBased());
+                str.append(i == 1 ? " and " : ", ");
             }
         }
-        return str;
+        str.append(indexes.get(0).getOneBased());
+        return str.toString();
     }
-
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
@@ -115,16 +115,15 @@ public class UnmarkCommand extends Command {
      * @return a {@code String} of the list of indexes that are passed into the function.
      */
     private String indexesToString(List<Index> indexes) {
-        String str = "" + indexes.get(0).getOneBased();
-        for (int i = 1; i < indexes.size(); i++) {
-            int index = indexes.get(i).getOneBased();
-            if (indexes.size() > 1 && i == indexes.size() - 1) {
-                str += " and " + index;
-            } else {
-                str += ", " + index;
+        StringBuilder str = new StringBuilder();
+        if (indexes.size() > 1) {
+            for (int i = indexes.size() - 1; i >= 1; i--) {
+                str.append(indexes.get(i).getOneBased());
+                str.append(i == 1 ? " and " : ", ");
             }
         }
-        return str;
+        str.append(indexes.get(0).getOneBased());
+        return str.toString();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/MassOpsParser.java
+++ b/src/main/java/seedu/address/logic/parser/MassOpsParser.java
@@ -22,9 +22,10 @@ public class MassOpsParser {
      * @throws ParseException
      */
     public static List<Index> massOpProcessor(String args) throws ParseException {
+        assert args.length() != 0;
+
         List<String> stringIndexes = new ArrayList<>(Arrays.asList(args.trim().split(" ")));
         List<Index> indexes = new ArrayList<>();
-
 
         for (int i = 0; i < stringIndexes.size(); i++) {
             Index index = ParserUtil.parseIndex(stringIndexes.get(i));
@@ -42,7 +43,6 @@ public class MassOpsParser {
      */
     public static List<Index> sortInAsc(List<Index> indexes) {
         assert indexes.size() != 0;
-        assert indexes != null;
 
         TreeSet<Index> sorted = new TreeSet<>(indexes);
         List<Index> ascIndexes = new ArrayList<>(sorted);
@@ -57,7 +57,6 @@ public class MassOpsParser {
      */
     public static List<Index> sortInDesc(List<Index> indexes) {
         assert indexes.size() != 0;
-        assert indexes != null;
 
         List<Index> descIndexes = sortInAsc(indexes);
         Collections.reverse(descIndexes);

--- a/src/main/java/seedu/address/logic/parser/MassOpsParser.java
+++ b/src/main/java/seedu/address/logic/parser/MassOpsParser.java
@@ -41,6 +41,9 @@ public class MassOpsParser {
      * @return a {@code List<Indexes>} sorted in ascending order.
      */
     public static List<Index> sortInAsc(List<Index> indexes) {
+        assert indexes.size() != 0;
+        assert indexes != null;
+
         TreeSet<Index> sorted = new TreeSet<>(indexes);
         List<Index> ascIndexes = new ArrayList<>(sorted);
         return ascIndexes;
@@ -53,6 +56,9 @@ public class MassOpsParser {
      * @return a {@code List<Indexes>} sorted in descending order.
      */
     public static List<Index> sortInDesc(List<Index> indexes) {
+        assert indexes.size() != 0;
+        assert indexes != null;
+
         List<Index> descIndexes = sortInAsc(indexes);
         Collections.reverse(descIndexes);
         return descIndexes;

--- a/src/test/data/JsonSerializableTaskListTest/typicalTaskList.json
+++ b/src/test/data/JsonSerializableTaskListTest/typicalTaskList.json
@@ -34,5 +34,12 @@
     "deadline" : "2022-04-01",
     "priority": "low",
     "tagged" : [ ]
+  }, {
+    "name" : "CS2102 Meeting",
+    "description" : "Meeting",
+    "isCompleted" : "true",
+    "deadline" : "2022-04-06",
+    "priority" : "medium",
+    "tagged" : [ ]
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
@@ -1,118 +1,368 @@
-//package seedu.address.logic.commands;
-//
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.junit.jupiter.api.Assertions.assertFalse;
-//import static org.junit.jupiter.api.Assertions.assertTrue;
-//import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPLETION_STATUS_TRUE;
-//import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-//import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-//import static seedu.address.logic.commands.CommandTestUtil.showTaskAtIndex;
-//import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
-//import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_TASK;
-//import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
-//
-//import org.junit.jupiter.api.Test;
-//
-//import seedu.address.commons.core.Messages;
-//import seedu.address.commons.core.index.Index;
-//import seedu.address.model.Model;
-//import seedu.address.model.ModelManager;
-//import seedu.address.model.UserPrefs;
-//import seedu.address.model.task.Task;
-//import seedu.address.testutil.TaskBuilder;
-//
-///**
-// * Contains integration tests (interaction with the Model) and unit tests for
-// * {@code MarkCommand}.
-// */
-//public class MarkCommandTest {
-//
-//    private Model model = new ModelManager(getTypicalTaskList(), new UserPrefs());
-//
-//    @Test
-//    public void execute_validIndexUnfilteredList_success() {
-//        Task taskToMark = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
-//        Task markedTask = new TaskBuilder(taskToMark).withCompletionStatus(VALID_COMPLETION_STATUS_TRUE).build();
-//        MarkCommand markCommand = new MarkCommand(INDEX_FIRST_TASK);
-//
-//        String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_TASK_SUCCESS, markedTask);
-//
-//        ModelManager expectedModel = new ModelManager(model.getTaskList(), new UserPrefs());
-//        expectedModel.strictSetTask(model.getFilteredTaskList().get(0), markedTask);
-//
-//        assertCommandSuccess(markCommand, model, expectedMessage, expectedModel);
-//    }
-//
-//    @Test
-//    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-//        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
-//        MarkCommand markCommand = new MarkCommand(outOfBoundIndex);
-//
-//        assertCommandFailure(markCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
-//    }
-//
-//    @Test
-//    public void execute_validCompletedTaskUnfilteredList_throwsCommandException() {
-//        // INDEX SECOND TASK: default completion status set to true
-//        Task taskToMark = model.getFilteredTaskList().get(INDEX_SECOND_TASK.getZeroBased());
-//        assertEquals(taskToMark.getCompletionStatus().value, "true");
-//
-//        MarkCommand markCommand = new MarkCommand(INDEX_SECOND_TASK);
-//
-//        assertCommandFailure(markCommand, model, MarkCommand.MESSAGE_TASK_ALREADY_COMPLETED);
-//    }
-//
-//
-//    @Test
-//    public void execute_validIndexFilteredList_success() {
-//        showTaskAtIndex(model, INDEX_FIRST_TASK);
-//
-//        Task taskToMark = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
-//        Task markedTask = new TaskBuilder(taskToMark).withCompletionStatus(VALID_COMPLETION_STATUS_TRUE).build();
-//        MarkCommand markCommand = new MarkCommand(INDEX_FIRST_TASK);
-//
-//        String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_TASK_SUCCESS, markedTask);
-//
-//        ModelManager expectedModel = new ModelManager(model.getTaskList(), new UserPrefs());
-//        expectedModel.strictSetTask(model.getFilteredTaskList().get(0), markedTask);
-//
-//        assertCommandSuccess(markCommand, model, expectedMessage, expectedModel);
-//    }
-//
-//    @Test
-//    public void execute_invalidIndexFilteredList_throwsCommandException() {
-//        showTaskAtIndex(model, INDEX_FIRST_TASK);
-//
-//        Index outOfBoundIndex = INDEX_SECOND_TASK;
-//        // ensures that outOfBoundIndex is still in bounds of task list
-//        assertTrue(outOfBoundIndex.getZeroBased() < model.getTaskList().getTaskList().size());
-//
-//        MarkCommand markCommand = new MarkCommand(outOfBoundIndex);
-//
-//        assertCommandFailure(markCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
-//    }
-//
-//
-//    @Test
-//    public void equals() {
-//        MarkCommand markFirstCommand = new MarkCommand(INDEX_FIRST_TASK);
-//        MarkCommand markSecondCommand = new MarkCommand(INDEX_SECOND_TASK);
-//
-//        // same object -> returns true
-//        assertTrue(markFirstCommand.equals(markFirstCommand));
-//
-//        // same values -> returns true
-//        MarkCommand markFirstCommandCopy = new MarkCommand(INDEX_FIRST_TASK);
-//        assertTrue(markFirstCommand.equals(markFirstCommandCopy));
-//
-//        // different types -> returns false
-//        assertFalse(markFirstCommand.equals(1));
-//
-//        // null -> returns false
-//        assertFalse(markFirstCommand.equals(null));
-//
-//        // different task -> returns false
-//        assertFalse(markFirstCommand.equals(markSecondCommand));
-//    }
-//
-//}
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPLETION_STATUS_TRUE;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showTaskAtIndex;
+import static seedu.address.testutil.TypicalIndexes.*;
+import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.task.Task;
+import seedu.address.testutil.TaskBuilder;
+
+import java.util.List;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code MarkCommand}.
+ */
+public class MarkCommandTest {
+
+    private Model model = new ModelManager(getTypicalTaskList(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        //task to mark
+        Task taskToMark = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
+
+        //marked task
+        Task markedTask = new TaskBuilder(taskToMark).withCompletionStatus(VALID_COMPLETION_STATUS_TRUE).build();
+        List<Task> markedTaskList = List.of(markedTask);
+
+        Index index = Index.fromOneBased(INDEX_FIRST_TASK.getOneBased());
+        List<Index> indexList = List.of(index);
+
+        MarkCommand markCommand = new MarkCommand(indexList);
+
+        String expectedMessage = getExpectedSuccessMessage(markedTaskList, indexList);
+
+        ModelManager expectedModel = new ModelManager(model.getTaskList(), new UserPrefs());
+        expectedModel.strictSetTask(model.getFilteredTaskList().get(0), markedTask);
+
+        assertCommandSuccess(markCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexesUnfilteredList_success() {
+        //task to mark
+        Task taskToMark1 = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
+        Task taskToMark2 = model.getFilteredTaskList().get(INDEX_SECOND_TASK.getZeroBased());
+
+        //marked task
+        Task markedTask1 = new TaskBuilder(taskToMark1).withCompletionStatus(VALID_COMPLETION_STATUS_TRUE).build();
+        Task markedTask2 = new TaskBuilder(taskToMark2).withCompletionStatus(VALID_COMPLETION_STATUS_TRUE).build();
+        List<Task> markedTasksList = List.of(markedTask1, markedTask2);
+
+        Index index1 = Index.fromOneBased(INDEX_FIRST_TASK.getOneBased());
+        Index index2 = Index.fromOneBased(INDEX_SECOND_TASK.getOneBased());
+        List<Index> indexesList = List.of(index1, index2);
+
+        MarkCommand markCommand = new MarkCommand(indexesList);
+
+        String expectedMessage = getExpectedSuccessMessage(markedTasksList, indexesList);
+
+        ModelManager expectedModel = new ModelManager(model.getTaskList(), new UserPrefs());
+        expectedModel.strictSetTask(model.getFilteredTaskList().get(0), markedTask1);
+        expectedModel.strictSetTask(model.getFilteredTaskList().get(1), markedTask2);
+
+        assertCommandSuccess(markCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        List<Index> alreadyMarkedIndexList = List.of();
+        List<Index> outOfBoundIndexList = List.of(outOfBoundIndex);
+        MarkCommand markCommand = new MarkCommand(outOfBoundIndexList);
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexList, alreadyMarkedIndexList);
+
+        assertCommandFailure(markCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_invalidIndexesUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex1 = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        Index outOfBoundIndex2 = Index.fromOneBased(model.getFilteredTaskList().size() + 2);
+        List<Index> alreadyMarkedIndexesList = List.of();
+        List<Index> outOfBoundIndexesList = List.of(outOfBoundIndex1, outOfBoundIndex2);
+
+        MarkCommand markCommand = new MarkCommand(outOfBoundIndexesList);
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexesList, alreadyMarkedIndexesList);
+
+        assertCommandFailure(markCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_validCompletedTaskUnfilteredList_throwsCommandException() {
+        // INDEX SECOND TASK: default completion status set to true
+        Task taskToMark = model.getFilteredTaskList().get(INDEX_FIFTH_TASK.getZeroBased());
+
+        assertEquals(taskToMark.getCompletionStatus().value, "true");
+
+        List<Index> outOfBoundIndexes = List.of();
+        Index alreadyMarkedIndex = Index.fromOneBased(INDEX_FIFTH_TASK.getOneBased());
+        List<Index> alreadyMarkedIndexList = List.of(alreadyMarkedIndex);
+
+        MarkCommand markCommand = new MarkCommand(alreadyMarkedIndexList);
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexes, alreadyMarkedIndexList);
+        assertCommandFailure(markCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_validCompletedTasksUnfilteredList_throwsCommandException() {
+        // INDEX SECOND TASK: default completion status set to true
+        Task taskToMark1 = model.getFilteredTaskList().get(INDEX_FIFTH_TASK.getZeroBased());
+        Task taskToMark2 = model.getFilteredTaskList().get(INDEX_SIXTH_TASK.getZeroBased());
+
+        assertEquals(taskToMark1.getCompletionStatus().value, "true");
+        assertEquals(taskToMark2.getCompletionStatus().value, "true");
+
+        List<Index> outOfBoundIndexesList = List.of();
+        Index index1 = Index.fromOneBased(INDEX_FIFTH_TASK.getOneBased());
+        Index index2 = Index.fromOneBased(INDEX_SIXTH_TASK.getOneBased());
+        List<Index> alreadyMarkedIndexesList = List.of(index1, index2);
+
+        MarkCommand markCommand = new MarkCommand(alreadyMarkedIndexesList);
+
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexesList, alreadyMarkedIndexesList);
+
+        assertCommandFailure(markCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_invalidIndexAndCompletedTaskUnfilteredList_throwsCommandException() {
+        // INDEX SECOND TASK: default completion status set to true
+        Task taskToMark = model.getFilteredTaskList().get(INDEX_FIFTH_TASK.getZeroBased());
+
+        assertEquals(taskToMark.getCompletionStatus().value, "true");
+
+        Index alreadyMarkedIndex = Index.fromOneBased(INDEX_FIFTH_TASK.getOneBased());
+        List<Index> alreadyMarkedIndexesList = List.of(alreadyMarkedIndex);
+
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        List<Index> outOfBoundIndexesList = List.of(outOfBoundIndex);
+
+        List<Index> indexesList = List.of(alreadyMarkedIndex, outOfBoundIndex);
+        MarkCommand markCommand = new MarkCommand(indexesList);
+
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexesList, alreadyMarkedIndexesList);
+
+        assertCommandFailure(markCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_validIndexAndInvalidIndexUnfilteredList_throwsCommandException() {
+        List<Index> alreadyMarkedTasksList = List.of();
+
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        List<Index> outOfBoundIndexList = List.of(outOfBoundIndex);
+
+        //task to mark
+        Index taskToMarkIndex = INDEX_FIRST_TASK;
+
+        List<Index> indexes = List.of(taskToMarkIndex, outOfBoundIndex);
+
+        MarkCommand markCommand = new MarkCommand(indexes);
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexList, alreadyMarkedTasksList);
+
+        assertCommandFailure(markCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_validIndexAndAlreadyMarkedIndexUnfilteredList_throwsCommandException() {
+        Index alreadyMarkedIndex = INDEX_FIFTH_TASK;
+        List<Index> alreadyMarkedIndexList = List.of(alreadyMarkedIndex);
+
+        List<Index> outOfBoundIndexList = List.of();
+
+        //task to mark
+        Index taskToMarkIndex = INDEX_FIRST_TASK;
+
+        List<Index> indexes = List.of(taskToMarkIndex, alreadyMarkedIndex);
+
+        MarkCommand markCommand = new MarkCommand(indexes);
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexList, alreadyMarkedIndexList);
+
+        assertCommandFailure(markCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_validIndexAndAlreadyMarkedIndexAndInvalidIndexUnfilteredList_throwsCommandException() {
+        Index alreadyMarkedIndex = INDEX_FIFTH_TASK;
+        List<Index> alreadyMarkedIndexList = List.of(alreadyMarkedIndex);
+
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        List<Index> outOfBoundIndexList = List.of(outOfBoundIndex);
+
+        //task to mark
+        Index taskToMarkIndex = INDEX_FIRST_TASK;
+
+        List<Index> indexes = List.of(taskToMarkIndex, alreadyMarkedIndex, outOfBoundIndex);
+
+        MarkCommand markCommand = new MarkCommand(indexes);
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexList, alreadyMarkedIndexList);
+
+        assertCommandFailure(markCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        List<Index> indexes = List.of(Index.fromZeroBased(0));
+        Task taskToMark = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
+        Task markedTask = new TaskBuilder(taskToMark).withCompletionStatus(VALID_COMPLETION_STATUS_TRUE).build();
+        List<Task> markedTaskList = List.of(markedTask);
+
+        MarkCommand markCommand = new MarkCommand(indexes);
+
+        String expectedMessage = getExpectedSuccessMessage(markedTaskList, indexes);
+
+        ModelManager expectedModel = new ModelManager(model.getTaskList(), new UserPrefs());
+        expectedModel.strictSetTask(model.getFilteredTaskList().get(0), markedTask);
+
+        showTaskAtIndex(model, INDEX_FIRST_TASK);
+        showTaskAtIndex(expectedModel, INDEX_FIRST_TASK);
+
+        assertCommandSuccess(markCommand, model, expectedMessage, expectedModel);
+    }
+
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showTaskAtIndex(model, INDEX_FIRST_TASK);
+        List<Index> alreadyMarkedTasksList = List.of();
+
+        Index outOfBoundIndex = INDEX_SECOND_TASK;
+        List<Index> outOfBoundIndexesList = List.of(outOfBoundIndex);
+        // ensures that outOfBoundIndex is still in bounds of task list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getTaskList().getTaskList().size());
+
+        MarkCommand markCommand = new MarkCommand(outOfBoundIndexesList);
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexesList, alreadyMarkedTasksList);
+
+        assertCommandFailure(markCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_alreadyMarkedIndexFilteredList_throwsCommandException() {
+        showTaskAtIndex(model, INDEX_FIFTH_TASK);
+        List<Index> alreadyMarkedTasksList = List.of(Index.fromZeroBased(0));
+        List<Index> outOfBoundIndexesList = List.of();
+
+        MarkCommand markCommand = new MarkCommand(alreadyMarkedTasksList);
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexesList, alreadyMarkedTasksList);
+
+        assertCommandFailure(markCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_invalidIndexAndAlreadyMarkedIndexFilteredList_throwsCommandException() {
+        showTaskAtIndex(model, INDEX_FIFTH_TASK);
+        Index alreadyMarkedIndex = Index.fromZeroBased(0);
+        List<Index> alreadyMarkedIndexList = List.of(alreadyMarkedIndex);
+        Index outOfBoundIndex = Index.fromZeroBased(1);
+        List<Index> outOfBoundIndexesList = List.of(outOfBoundIndex);
+        List<Index> indexes = List.of(alreadyMarkedIndex, outOfBoundIndex);
+
+        // ensures that outOfBoundIndex is still in bounds of task list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getTaskList().getTaskList().size());
+
+        MarkCommand markCommand = new MarkCommand(indexes);
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexesList, alreadyMarkedIndexList);
+
+        assertCommandFailure(markCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void equals() {
+        MarkCommand markFirstCommand = new MarkCommand(List.of(INDEX_FIRST_TASK));
+        MarkCommand markSecondCommand = new MarkCommand(List.of(INDEX_SECOND_TASK));
+        MarkCommand markFirstAndSecondCommand = new MarkCommand(List.of(INDEX_FIRST_TASK, INDEX_SECOND_TASK));
+        MarkCommand markSecondAndFirstCommand = new MarkCommand(List.of(INDEX_SECOND_TASK, INDEX_FIRST_TASK));
+
+        // same object -> returns true
+        assertTrue(markFirstCommand.equals(markFirstCommand));
+        assertTrue(markFirstAndSecondCommand.equals(markFirstAndSecondCommand));
+
+        // same values -> returns true
+        MarkCommand markFirstCommandCopy = new MarkCommand(List.of(INDEX_FIRST_TASK));
+        MarkCommand markFirstAndSecondCommandCopy = new MarkCommand(List.of(INDEX_FIRST_TASK, INDEX_SECOND_TASK));
+        MarkCommand markSecondAndFirstCommandCopy = new MarkCommand(List.of(INDEX_SECOND_TASK, INDEX_FIRST_TASK));
+        assertTrue(markFirstCommand.equals(markFirstCommandCopy));
+        assertTrue(markFirstAndSecondCommand.equals(markSecondAndFirstCommand));
+        assertTrue(markFirstAndSecondCommand.equals(markFirstAndSecondCommandCopy));
+        assertTrue(markSecondAndFirstCommand.equals(markSecondAndFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(markFirstCommand.equals(1));
+        assertFalse(markFirstAndSecondCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(markFirstCommand.equals(null));
+        assertFalse(markFirstAndSecondCommand.equals(null));
+
+        // different task -> returns false
+        assertFalse(markFirstCommand.equals(markSecondCommand));
+        assertFalse(markFirstAndSecondCommand.equals(markFirstCommand));
+    }
+
+    @Test
+    private String indexesToString(List<Index> indexes) {
+        StringBuilder str = new StringBuilder();
+        if (indexes.size() > 1) {
+            for (int i = indexes.size() - 1; i >= 1; i--) {
+                str.append(indexes.get(i).getOneBased());
+                str.append(i == 1 ? " and " : ", ");
+            }
+        }
+        str.append(indexes.get(0).getOneBased());
+        return str.toString();
+    }
+
+    @Test
+    private String getExpectedSuccessMessage(List<Task> markedTasks, List<Index> markedTasksIndexes) {
+        String str = "Successfully Marked Task(s): \n";
+        for (int i = 0; i < markedTasks.size(); i++) {
+            str += markedTasksIndexes.get(i).getOneBased() + ". " + markedTasks.get(i) + "\n";
+        }
+        return str;
+    }
+
+    /**
+     * Returns the expected error message.
+     */
+    private String getExpectedErrorMessage(List<Index> outOfBoundsIndexes, List<Index> alreadyMarkedIndexes) {
+        StringBuilder errorString = new StringBuilder();
+
+        if (!alreadyMarkedIndexes.isEmpty()) {
+            if (alreadyMarkedIndexes.size() == 1) {
+                errorString.append("Index " + indexesToString(alreadyMarkedIndexes) + ": "
+                        + MarkCommand.MESSAGE_TASK_ALREADY_COMPLETED + "\n");
+            } else {
+                errorString.append("Indexes " + indexesToString(alreadyMarkedIndexes) + ": "
+                        + MarkCommand.MESSAGE_MULTIPLE_TASKS_ALREADY_COMPLETED + "\n");
+            }
+        }
+
+        if (!outOfBoundsIndexes.isEmpty()) {
+            if (outOfBoundsIndexes.size() == 1) {
+                errorString.append("Index " + indexesToString(outOfBoundsIndexes) + ": "
+                        + Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX + "\n");
+            } else {
+                errorString.append("Indexes " + indexesToString(outOfBoundsIndexes) + ": "
+                        + Messages.MESSAGE_INVALID_MULTIPLE_TASK_DISPLAYED_INDEX + "\n");
+            }
+        }
+
+        return errorString.toString();
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
@@ -7,8 +7,13 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPLETION_STAT
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showTaskAtIndex;
-import static seedu.address.testutil.TypicalIndexes.*;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIFTH_TASK;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_TASK;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SIXTH_TASK;
 import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +25,6 @@ import seedu.address.model.UserPrefs;
 import seedu.address.model.task.Task;
 import seedu.address.testutil.TaskBuilder;
 
-import java.util.List;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for

--- a/src/test/java/seedu/address/logic/commands/UnmarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnmarkCommandTest.java
@@ -7,8 +7,13 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPLETION_STAT
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showTaskAtIndex;
-import static seedu.address.testutil.TypicalIndexes.*;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIFTH_TASK;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_TASK;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SIXTH_TASK;
 import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +25,6 @@ import seedu.address.model.UserPrefs;
 import seedu.address.model.task.Task;
 import seedu.address.testutil.TaskBuilder;
 
-import java.util.List;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for

--- a/src/test/java/seedu/address/logic/commands/UnmarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnmarkCommandTest.java
@@ -1,121 +1,368 @@
-//package seedu.address.logic.commands;
-//
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.junit.jupiter.api.Assertions.assertFalse;
-//import static org.junit.jupiter.api.Assertions.assertTrue;
-//import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPLETION_STATUS_FALSE;
-//import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-//import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-//import static seedu.address.logic.commands.CommandTestUtil.showTaskAtIndex;
-//import static seedu.address.testutil.TypicalIndexes.INDEX_FIFTH_TASK;
-//import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
-//import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_TASK;
-//import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
-//
-//import org.junit.jupiter.api.Test;
-//
-//import seedu.address.commons.core.Messages;
-//import seedu.address.commons.core.index.Index;
-//import seedu.address.model.Model;
-//import seedu.address.model.ModelManager;
-//import seedu.address.model.UserPrefs;
-//import seedu.address.model.task.Task;
-//import seedu.address.testutil.TaskBuilder;
-//
-///**
-// * Contains integration tests (interaction with the Model) and unit tests for
-// * {@code UnmarkCommand}.
-// */
-//public class UnmarkCommandTest {
-//
-//    private Model model = new ModelManager(getTypicalTaskList(), new UserPrefs());
-//
-//    @Test
-//    public void execute_validIndexUnfilteredList_success() {
-//        Task taskToUnmark = model.getFilteredTaskList().get(INDEX_SECOND_TASK.getZeroBased());
-//        Task unmarkedTask = new TaskBuilder(taskToUnmark).withCompletionStatus(VALID_COMPLETION_STATUS_FALSE).build();
-//
-//        UnmarkCommand unmarkCommand = new UnmarkCommand(INDEX_SECOND_TASK);
-//        String expectedMessage = String.format(UnmarkCommand.MESSAGE_UNMARK_TASK_SUCCESS, unmarkedTask);
-//
-//        ModelManager expectedModel = new ModelManager(model.getTaskList(), new UserPrefs());
-//        expectedModel.strictSetTask(model.getFilteredTaskList().get(INDEX_SECOND_TASK.getZeroBased()), unmarkedTask);
-//
-//        assertCommandSuccess(unmarkCommand, model, expectedMessage, expectedModel);
-//    }
-//
-//    @Test
-//    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-//        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
-//        MarkCommand markCommand = new MarkCommand(outOfBoundIndex);
-//
-//        assertCommandFailure(markCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
-//    }
-//
-//    @Test
-//    public void execute_validCompletedTaskUnfilteredList_throwsCommandException() {
-//        // INDEX FIRST TASK: default completion status set to false
-//        Task taskToUnmark = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
-//        assertEquals(taskToUnmark.getCompletionStatus().value, "false");
-//
-//        UnmarkCommand unmarkCommand = new UnmarkCommand(INDEX_FIRST_TASK);
-//
-//        assertCommandFailure(unmarkCommand, model, UnmarkCommand.MESSAGE_TASK_ALREADY_UNCOMPLETED);
-//    }
-//
-//
-//    @Test
-//    public void execute_validIndexFilteredList_success() {
-//        showTaskAtIndex(model, INDEX_FIFTH_TASK);
-//
-//        // Note: FilteredTaskList will have only taskToUnmark i.e. taskToUnmark is at the INDEX_FIRST_TASK
-//        Task taskToUnmark = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
-//        Task unmarkedTask = new TaskBuilder(taskToUnmark).withCompletionStatus(VALID_COMPLETION_STATUS_FALSE).build();
-//
-//        UnmarkCommand unmarkCommand = new UnmarkCommand(INDEX_FIRST_TASK);
-//
-//        String expectedMessage = String.format(UnmarkCommand.MESSAGE_UNMARK_TASK_SUCCESS, unmarkedTask);
-//
-//        ModelManager expectedModel = new ModelManager(model.getTaskList(), new UserPrefs());
-//        expectedModel.strictSetTask(model.getFilteredTaskList().get(0), unmarkedTask);
-//
-//        assertCommandSuccess(unmarkCommand, model, expectedMessage, expectedModel);
-//    }
-//
-//    @Test
-//    public void execute_invalidIndexFilteredList_throwsCommandException() {
-//        showTaskAtIndex(model, INDEX_FIRST_TASK);
-//
-//        Index outOfBoundIndex = INDEX_SECOND_TASK;
-//        // ensures that outOfBoundIndex is still in bounds of task list
-//        assertTrue(outOfBoundIndex.getZeroBased() < model.getTaskList().getTaskList().size());
-//
-//        UnmarkCommand unmarkCommand = new UnmarkCommand(outOfBoundIndex);
-//
-//        assertCommandFailure(unmarkCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
-//    }
-//
-//
-//    @Test
-//    public void equals() {
-//        UnmarkCommand unmarkFirstCommand = new UnmarkCommand(INDEX_FIRST_TASK);
-//        UnmarkCommand unmarkSecondCommand = new UnmarkCommand(INDEX_SECOND_TASK);
-//
-//        // same object -> returns true
-//        assertTrue(unmarkFirstCommand.equals(unmarkFirstCommand));
-//
-//        // same values -> returns true
-//        UnmarkCommand unmarkFirstCommandCopy = new UnmarkCommand(INDEX_FIRST_TASK);
-//        assertTrue(unmarkFirstCommand.equals(unmarkFirstCommandCopy));
-//
-//        // different types -> returns false
-//        assertFalse(unmarkFirstCommand.equals(1));
-//
-//        // null -> returns false
-//        assertFalse(unmarkFirstCommand.equals(null));
-//
-//        // different task -> returns false
-//        assertFalse(unmarkFirstCommand.equals(unmarkSecondCommand));
-//    }
-//
-//}
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPLETION_STATUS_FALSE;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showTaskAtIndex;
+import static seedu.address.testutil.TypicalIndexes.*;
+import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.task.Task;
+import seedu.address.testutil.TaskBuilder;
+
+import java.util.List;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code UnmarkCommand}.
+ */
+public class UnmarkCommandTest {
+
+    private Model model = new ModelManager(getTypicalTaskList(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        //task to unmark
+        Task taskToUnmark = model.getFilteredTaskList().get(INDEX_FIFTH_TASK.getZeroBased());
+
+        //unmarked task
+        Task unmarkedTask = new TaskBuilder(taskToUnmark).withCompletionStatus(VALID_COMPLETION_STATUS_FALSE).build();
+        List<Task> unmarkedTaskList = List.of(unmarkedTask);
+
+        Index index = Index.fromOneBased(INDEX_FIFTH_TASK.getOneBased());
+        List<Index> indexList = List.of(index);
+
+        UnmarkCommand unmarkCommand = new UnmarkCommand(indexList);
+
+        String expectedMessage = getExpectedSuccessMessage(unmarkedTaskList, indexList);
+
+        ModelManager expectedModel = new ModelManager(model.getTaskList(), new UserPrefs());
+        expectedModel.strictSetTask(model.getFilteredTaskList().get(4), unmarkedTask);
+
+        assertCommandSuccess(unmarkCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexesUnfilteredList_success() {
+        //task to unmark
+        Task taskToUnmark1 = model.getFilteredTaskList().get(INDEX_FIFTH_TASK.getZeroBased());
+        Task taskToUnmark2 = model.getFilteredTaskList().get(INDEX_SIXTH_TASK.getZeroBased());
+
+        //unmarked task
+        Task unmarkedTask1 = new TaskBuilder(taskToUnmark1).withCompletionStatus(VALID_COMPLETION_STATUS_FALSE).build();
+        Task unmarkedTask2 = new TaskBuilder(taskToUnmark2).withCompletionStatus(VALID_COMPLETION_STATUS_FALSE).build();
+        List<Task> unmarkedTasksList = List.of(unmarkedTask1, unmarkedTask2);
+
+        Index index1 = Index.fromOneBased(INDEX_FIFTH_TASK.getOneBased());
+        Index index2 = Index.fromOneBased(INDEX_SIXTH_TASK.getOneBased());
+        List<Index> indexesList = List.of(index1, index2);
+
+        UnmarkCommand unmarkCommand = new UnmarkCommand(indexesList);
+
+        String expectedMessage = getExpectedSuccessMessage(unmarkedTasksList, indexesList);
+
+        ModelManager expectedModel = new ModelManager(model.getTaskList(), new UserPrefs());
+        expectedModel.strictSetTask(model.getFilteredTaskList().get(4), unmarkedTask1);
+        expectedModel.strictSetTask(model.getFilteredTaskList().get(5), unmarkedTask2);
+
+        assertCommandSuccess(unmarkCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        List<Index> alreadyUnmarkedIndexList = List.of();
+        List<Index> outOfBoundIndexList = List.of(outOfBoundIndex);
+        UnmarkCommand unmarkCommand = new UnmarkCommand(outOfBoundIndexList);
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexList, alreadyUnmarkedIndexList);
+
+        assertCommandFailure(unmarkCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_invalidIndexesUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex1 = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        Index outOfBoundIndex2 = Index.fromOneBased(model.getFilteredTaskList().size() + 2);
+        List<Index> alreadyUnmarkedIndexesList = List.of();
+        List<Index> outOfBoundIndexesList = List.of(outOfBoundIndex1, outOfBoundIndex2);
+
+        UnmarkCommand unmarkCommand = new UnmarkCommand(outOfBoundIndexesList);
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexesList, alreadyUnmarkedIndexesList);
+
+        assertCommandFailure(unmarkCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_validCompletedTaskUnfilteredList_throwsCommandException() {
+        // INDEX SECOND TASK: default completion status set to false
+        Task taskToUnmark = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
+
+        assertEquals(taskToUnmark.getCompletionStatus().value, "false");
+
+        List<Index> outOfBoundIndexes = List.of();
+        Index alreadyUnmarkedIndex = Index.fromOneBased(INDEX_FIRST_TASK.getOneBased());
+        List<Index> alreadyUnmarkedIndexList = List.of(alreadyUnmarkedIndex);
+
+        UnmarkCommand unmarkCommand = new UnmarkCommand(alreadyUnmarkedIndexList);
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexes, alreadyUnmarkedIndexList);
+        assertCommandFailure(unmarkCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_validCompletedTasksUnfilteredList_throwsCommandException() {
+        // INDEX SECOND TASK: default completion status set to false
+        Task taskToUnmark1 = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
+        Task taskToUnmark2 = model.getFilteredTaskList().get(INDEX_SECOND_TASK.getZeroBased());
+
+        assertEquals(taskToUnmark1.getCompletionStatus().value, "false");
+        assertEquals(taskToUnmark2.getCompletionStatus().value, "false");
+
+        List<Index> outOfBoundIndexesList = List.of();
+        Index index1 = Index.fromOneBased(INDEX_FIRST_TASK.getOneBased());
+        Index index2 = Index.fromOneBased(INDEX_SECOND_TASK.getOneBased());
+        List<Index> alreadyUnmarkedIndexesList = List.of(index1, index2);
+
+        UnmarkCommand unmarkCommand = new UnmarkCommand(alreadyUnmarkedIndexesList);
+
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexesList, alreadyUnmarkedIndexesList);
+
+        assertCommandFailure(unmarkCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_invalidIndexAndCompletedTaskUnfilteredList_throwsCommandException() {
+        // INDEX SECOND TASK: default completion status set to false
+        Task taskToUnmark = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
+
+        assertEquals(taskToUnmark.getCompletionStatus().value, "false");
+
+        Index alreadyUnmarkedIndex = Index.fromOneBased(INDEX_FIRST_TASK.getOneBased());
+        List<Index> alreadyUnmarkedIndexesList = List.of(alreadyUnmarkedIndex);
+
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        List<Index> outOfBoundIndexesList = List.of(outOfBoundIndex);
+
+        List<Index> indexesList = List.of(alreadyUnmarkedIndex, outOfBoundIndex);
+        UnmarkCommand unmarkCommand = new UnmarkCommand(indexesList);
+
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexesList, alreadyUnmarkedIndexesList);
+
+        assertCommandFailure(unmarkCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_validIndexAndInvalidIndexUnfilteredList_throwsCommandException() {
+        List<Index> alreadyUnmarkedTasksList = List.of();
+
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        List<Index> outOfBoundIndexList = List.of(outOfBoundIndex);
+
+        //task to unmark
+        Index taskToUnmarkIndex = INDEX_FIFTH_TASK;
+
+        List<Index> indexes = List.of(taskToUnmarkIndex, outOfBoundIndex);
+
+        UnmarkCommand unmarkCommand = new UnmarkCommand(indexes);
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexList, alreadyUnmarkedTasksList);
+
+        assertCommandFailure(unmarkCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_validIndexAndAlreadyUnmarkedIndexUnfilteredList_throwsCommandException() {
+        Index alreadyUnmarkedIndex = INDEX_FIRST_TASK;
+        List<Index> alreadyUnmarkedIndexList = List.of(alreadyUnmarkedIndex);
+
+        List<Index> outOfBoundIndexList = List.of();
+
+        //task to unmark
+        Index taskToUnmarkIndex = INDEX_FIFTH_TASK;
+
+        List<Index> indexes = List.of(taskToUnmarkIndex, alreadyUnmarkedIndex);
+
+        UnmarkCommand unmarkCommand = new UnmarkCommand(indexes);
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexList, alreadyUnmarkedIndexList);
+
+        assertCommandFailure(unmarkCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_validIndexAndAlreadyUnmarkedIndexAndInvalidIndexUnfilteredList_throwsCommandException() {
+        Index alreadyUnmarkedIndex = INDEX_FIRST_TASK;
+        List<Index> alreadyUnmarkedIndexList = List.of(alreadyUnmarkedIndex);
+
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        List<Index> outOfBoundIndexList = List.of(outOfBoundIndex);
+
+        //task to unmark
+        Index taskToUnmarkIndex = INDEX_FIFTH_TASK;
+
+        List<Index> indexes = List.of(taskToUnmarkIndex, alreadyUnmarkedIndex, outOfBoundIndex);
+
+        UnmarkCommand unmarkCommand = new UnmarkCommand(indexes);
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexList, alreadyUnmarkedIndexList);
+
+        assertCommandFailure(unmarkCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showTaskAtIndex(model, INDEX_FIFTH_TASK);
+
+        List<Index> indexes = List.of(Index.fromZeroBased(0));
+        Task taskToUnmark = model.getFilteredTaskList().get(0);
+        Task unmarkedTask = new TaskBuilder(taskToUnmark).withCompletionStatus(VALID_COMPLETION_STATUS_FALSE).build();
+        List<Task> unmarkedTaskList = List.of(unmarkedTask);
+
+        UnmarkCommand unmarkCommand = new UnmarkCommand(indexes);
+
+        String expectedMessage = getExpectedSuccessMessage(unmarkedTaskList, indexes);
+
+        ModelManager expectedModel = new ModelManager(model.getTaskList(), new UserPrefs());
+        expectedModel.strictSetTask(model.getFilteredTaskList().get(0), unmarkedTask);
+
+        showTaskAtIndex(expectedModel, INDEX_FIFTH_TASK);
+        assertCommandSuccess(unmarkCommand, model, expectedMessage, expectedModel);
+    }
+
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showTaskAtIndex(model, INDEX_FIRST_TASK);
+        List<Index> alreadyUnmarkedTasksList = List.of();
+
+        Index outOfBoundIndex = INDEX_SECOND_TASK;
+        List<Index> outOfBoundIndexesList = List.of(outOfBoundIndex);
+        // ensures that outOfBoundIndex is still in bounds of task list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getTaskList().getTaskList().size());
+
+        UnmarkCommand unmarkCommand = new UnmarkCommand(outOfBoundIndexesList);
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexesList, alreadyUnmarkedTasksList);
+
+        assertCommandFailure(unmarkCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_alreadyUnmarkedIndexFilteredList_throwsCommandException() {
+        showTaskAtIndex(model, INDEX_FIRST_TASK);
+        List<Index> alreadyUnmarkedTasksList = List.of(Index.fromZeroBased(0));
+        List<Index> outOfBoundIndexesList = List.of();
+
+        UnmarkCommand unmarkCommand = new UnmarkCommand(alreadyUnmarkedTasksList);
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexesList, alreadyUnmarkedTasksList);
+
+        assertCommandFailure(unmarkCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_invalidIndexAndAlreadyUnmarkedIndexFilteredList_throwsCommandException() {
+        showTaskAtIndex(model, INDEX_FIRST_TASK);
+        Index alreadyUnmarkedIndex = Index.fromZeroBased(0);
+        List<Index> alreadyUnmarkedIndexList = List.of(alreadyUnmarkedIndex);
+        Index outOfBoundIndex = Index.fromZeroBased(1);
+        List<Index> outOfBoundIndexesList = List.of(outOfBoundIndex);
+        List<Index> indexes = List.of(alreadyUnmarkedIndex, outOfBoundIndex);
+
+        // ensures that outOfBoundIndex is still in bounds of task list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getTaskList().getTaskList().size());
+
+        UnmarkCommand unmarkCommand = new UnmarkCommand(indexes);
+        String expectedMessage = getExpectedErrorMessage(outOfBoundIndexesList, alreadyUnmarkedIndexList);
+
+        assertCommandFailure(unmarkCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void equals() {
+        UnmarkCommand unmarkFirstCommand = new UnmarkCommand(List.of(INDEX_FIRST_TASK));
+        UnmarkCommand unmarkSecondCommand = new UnmarkCommand(List.of(INDEX_SECOND_TASK));
+        UnmarkCommand unmarkFirstAndSecondCommand = new UnmarkCommand(List.of(INDEX_FIRST_TASK, INDEX_SECOND_TASK));
+        UnmarkCommand unmarkSecondAndFirstCommand = new UnmarkCommand(List.of(INDEX_SECOND_TASK, INDEX_FIRST_TASK));
+
+        // same object -> returns true
+        assertTrue(unmarkFirstCommand.equals(unmarkFirstCommand));
+        assertTrue(unmarkFirstAndSecondCommand.equals(unmarkFirstAndSecondCommand));
+
+        // same values -> returns true
+        UnmarkCommand unmarkFirstCommandCopy = new UnmarkCommand(List.of(INDEX_FIRST_TASK));
+        UnmarkCommand unmarkFirstAndSecondCommandCopy = new UnmarkCommand(List.of(INDEX_FIRST_TASK, INDEX_SECOND_TASK));
+        UnmarkCommand unmarkSecondAndFirstCommandCopy = new UnmarkCommand(List.of(INDEX_SECOND_TASK, INDEX_FIRST_TASK));
+        assertTrue(unmarkFirstCommand.equals(unmarkFirstCommandCopy));
+        assertTrue(unmarkFirstAndSecondCommand.equals(unmarkSecondAndFirstCommand));
+        assertTrue(unmarkFirstAndSecondCommand.equals(unmarkFirstAndSecondCommandCopy));
+        assertTrue(unmarkSecondAndFirstCommand.equals(unmarkSecondAndFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(unmarkFirstCommand.equals(1));
+        assertFalse(unmarkFirstAndSecondCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(unmarkFirstCommand.equals(null));
+        assertFalse(unmarkFirstAndSecondCommand.equals(null));
+
+        // different task -> returns false
+        assertFalse(unmarkFirstCommand.equals(unmarkSecondCommand));
+        assertFalse(unmarkFirstAndSecondCommand.equals(unmarkFirstCommand));
+    }
+
+    @Test
+    private String indexesToString(List<Index> indexes) {
+        StringBuilder str = new StringBuilder();
+        if (indexes.size() > 1) {
+            for (int i = indexes.size() - 1; i >= 1; i--) {
+                str.append(indexes.get(i).getOneBased());
+                str.append(i == 1 ? " and " : ", ");
+            }
+        }
+        str.append(indexes.get(0).getOneBased());
+        return str.toString();
+    }
+
+    @Test
+    private String getExpectedSuccessMessage(List<Task> unmarkedTasks, List<Index> unmarkedTasksIndexes) {
+        String str = "Successfully Unmarked Task(s): \n";
+        for (int i = 0; i < unmarkedTasks.size(); i++) {
+            str += unmarkedTasksIndexes.get(i).getOneBased() + ". " + unmarkedTasks.get(i) + "\n";
+        }
+        return str;
+    }
+
+    /**
+     * Returns the expected error message.
+     */
+    private String getExpectedErrorMessage(List<Index> outOfBoundsIndexes, List<Index> alreadyUnmarkedIndexes) {
+        StringBuilder errorString = new StringBuilder();
+
+        if (!alreadyUnmarkedIndexes.isEmpty()) {
+            if (alreadyUnmarkedIndexes.size() == 1) {
+                errorString.append("Index " + indexesToString(alreadyUnmarkedIndexes) + ": "
+                        + UnmarkCommand.MESSAGE_TASK_ALREADY_UNCOMPLETED + "\n");
+            } else {
+                errorString.append("Indexes " + indexesToString(alreadyUnmarkedIndexes) + ": "
+                        + UnmarkCommand.MESSAGE_MULTIPLE_TASKS_ALREADY_UNCOMPLETED + "\n");
+            }
+        }
+
+        if (!outOfBoundsIndexes.isEmpty()) {
+            if (outOfBoundsIndexes.size() == 1) {
+                errorString.append("Index " + indexesToString(outOfBoundsIndexes) + ": "
+                        + Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX + "\n");
+            } else {
+                errorString.append("Indexes " + indexesToString(outOfBoundsIndexes) + ": "
+                        + Messages.MESSAGE_INVALID_MULTIPLE_TASK_DISPLAYED_INDEX + "\n");
+            }
+        }
+
+        return errorString.toString();
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/HarmoniaParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/HarmoniaParserTest.java
@@ -7,7 +7,10 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIFTH_TASK;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_TASK;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SIXTH_TASK;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -16,14 +19,18 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditTaskDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.MarkCommand;
+import seedu.address.logic.commands.UnmarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.TagContainsKeywordsPredicate;
 import seedu.address.model.task.DeadlineInRangePredicate;
@@ -34,7 +41,6 @@ import seedu.address.testutil.TaskBuilder;
 import seedu.address.testutil.TaskUtil;
 
 public class HarmoniaParserTest {
-
     private final HarmoniaParser parser = new HarmoniaParser();
 
     @Test
@@ -50,12 +56,14 @@ public class HarmoniaParserTest {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
     }
 
-    //    @Test
-    //    public void parseCommand_delete() throws Exception {
-    //        DeleteCommand command = (DeleteCommand) parser.parseCommand(
-    //                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_TASK.getOneBased());
-    //        assertEquals(new DeleteCommand(INDEX_FIRST_TASK), command);
-    //    }
+    @Test
+    public void parseCommand_delete() throws Exception {
+        DeleteCommand command = (DeleteCommand) parser.parseCommand(
+                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_TASK.getOneBased() + " "
+                        + INDEX_SECOND_TASK.getOneBased());
+        List<Index> indexes = List.of(INDEX_FIRST_TASK, INDEX_SECOND_TASK);
+        assertEquals(new DeleteCommand(indexes), command);
+    }
 
     @Test
     public void parseCommand_edit() throws Exception {
@@ -103,19 +111,23 @@ public class HarmoniaParserTest {
         assertEquals(new ListCommand(true), listTagsCommand);
     }
 
-    //    @Test
-    //    public void parseCommand_mark() throws Exception {
-    //        MarkCommand command = (MarkCommand) parser.parseCommand(
-    //                MarkCommand.COMMAND_WORD + " " + INDEX_FIRST_TASK.getOneBased());
-    //        assertEquals(new MarkCommand(INDEX_FIRST_TASK), command);
-    //    }
-    //
-    //    @Test
-    //    public void parseCommand_unmark() throws Exception {
-    //        UnmarkCommand command = (UnmarkCommand) parser.parseCommand(
-    //                UnmarkCommand.COMMAND_WORD + " " + INDEX_SECOND_TASK.getOneBased());
-    //        assertEquals(new UnmarkCommand(INDEX_SECOND_TASK), command);
-    //    }
+    @Test
+    public void parseCommand_mark() throws Exception {
+        MarkCommand command = (MarkCommand) parser.parseCommand(
+                MarkCommand.COMMAND_WORD + " " + INDEX_FIRST_TASK.getOneBased() + " "
+                        + INDEX_SECOND_TASK.getOneBased());
+        List<Index> indexes = List.of(INDEX_FIRST_TASK, INDEX_SECOND_TASK);
+        assertEquals(new MarkCommand(indexes), command);
+    }
+
+    @Test
+    public void parseCommand_unmark() throws Exception {
+        UnmarkCommand command = (UnmarkCommand) parser.parseCommand(
+                UnmarkCommand.COMMAND_WORD + " " + INDEX_FIFTH_TASK.getOneBased() + " "
+                        + INDEX_SIXTH_TASK.getOneBased());
+        List<Index> indexes = List.of(INDEX_FIFTH_TASK, INDEX_SIXTH_TASK);
+        assertEquals(new UnmarkCommand(indexes), command);
+    }
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {

--- a/src/test/java/seedu/address/logic/parser/MarkCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MarkCommandParserTest.java
@@ -5,11 +5,13 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.MarkCommand;
 
-import java.util.List;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
@@ -24,7 +26,7 @@ public class MarkCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsMarkCommand() {
-        List indexList = List.of(INDEX_FIRST_TASK);
+        List<Index> indexList = List.of(INDEX_FIRST_TASK);
         assertParseSuccess(parser, "1", new MarkCommand(indexList));
     }
 

--- a/src/test/java/seedu/address/logic/parser/MarkCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MarkCommandParserTest.java
@@ -1,32 +1,35 @@
-//package seedu.address.logic.parser;
-//
-//import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-//import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
-//import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-//import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
-//
-//import org.junit.jupiter.api.Test;
-//
-//import seedu.address.logic.commands.MarkCommand;
-//
-///**
-// * As we are only doing white-box testing, our test cases do not cover path variations
-// * outside of the MarkCommand code. For example, inputs "1" and "1 abc" take the
-// * same path through the MarkCommand, and therefore we test only one of them.
-// * The path variation for those two cases occur inside the ParserUtil, and
-// * therefore should be covered by the ParserUtilTest.
-// */
-//public class MarkCommandParserTest {
-//
-//    private MarkCommandParser parser = new MarkCommandParser();
-//
-//    @Test
-//    public void parse_validArgs_returnsMarkCommand() {
-//        assertParseSuccess(parser, "1", new MarkCommand(INDEX_FIRST_TASK));
-//    }
-//
-//    @Test
-//    public void parse_invalidArgs_throwsParseException() {
-//        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
-//    }
-//}
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.MarkCommand;
+
+import java.util.List;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the MarkCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the MarkCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class MarkCommandParserTest {
+
+    private MarkCommandParser parser = new MarkCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsMarkCommand() {
+        List indexList = List.of(INDEX_FIRST_TASK);
+        assertParseSuccess(parser, "1", new MarkCommand(indexList));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/MassOpsParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MassOpsParserTest.java
@@ -1,0 +1,74 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Contains tests for parsing of multiple of indexes for MassOps commands.
+ */
+public class MassOpsParserTest {
+    @Test
+    public void parseMassOps_validArgs_returnsIndexesList() throws ParseException {
+        String indexesStr = "1 2 3 6";
+        List<Index> indexesList = List.of(Index.fromOneBased(1), Index.fromOneBased(2), Index.fromOneBased(3),
+                Index.fromOneBased(6));
+        assertTrue(MassOpsParser.massOpProcessor(indexesStr).equals(indexesList));
+    }
+
+    @Test
+    public void parseMassOps_invalidLtrArg_throwsParseException() throws ParseException {
+        String indexesStr = "1 2 3 a";
+        assertThrows(ParseException.class, "Index is not a non-zero unsigned integer.", (
+            ) -> MassOpsParser.massOpProcessor(indexesStr));
+    }
+
+    @Test
+    public void parseMassOps_invalidIndexArg_throwsParseException() throws ParseException {
+        String indexesStr = "-1 2 3 4";
+        assertThrows(ParseException.class, "Index is not a non-zero unsigned integer.", (
+            ) -> MassOpsParser.massOpProcessor(indexesStr));
+    }
+
+    @Test
+    public void parseMassOps_emptyStr_throwsParseException() throws ParseException {
+        String indexesStr = "";
+        assertThrows(AssertionError.class, () -> MassOpsParser.massOpProcessor(indexesStr));
+    }
+
+    @Test
+    public void sortAsc_validArgs() throws ParseException {
+        List<Index> indexes = List.of(Index.fromOneBased(5), Index.fromOneBased(4), Index.fromOneBased(1),
+                Index.fromOneBased(3));
+        List<Index> expectedIndexes = List.of(Index.fromOneBased(1), Index.fromOneBased(3), Index.fromOneBased(4),
+                Index.fromOneBased(5));
+        assertTrue(MassOpsParser.sortInAsc(indexes).equals(expectedIndexes));
+    }
+
+    @Test
+    public void sortAsc_invalidIndexArg_throwsParseException() throws ParseException {
+        List<Index> indexes = List.of();
+        assertThrows(AssertionError.class, ()-> MassOpsParser.sortInAsc(indexes));
+    }
+
+    @Test
+    public void sortDesc_validArgs() throws ParseException {
+        List<Index> indexes = List.of(Index.fromOneBased(5), Index.fromOneBased(4), Index.fromOneBased(1),
+                Index.fromOneBased(3));
+        List<Index> expectedIndexes = List.of(Index.fromOneBased(5), Index.fromOneBased(4), Index.fromOneBased(3),
+                Index.fromOneBased(1));
+        assertTrue(MassOpsParser.sortInDesc(indexes).equals(expectedIndexes));
+    }
+
+    @Test
+    public void sortDesc_invalidIndexArg_throwsParseException() throws ParseException {
+        List<Index> indexes = List.of();
+        assertThrows(AssertionError.class, () -> MassOpsParser.sortInDesc(indexes));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/UnmarkCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnmarkCommandParserTest.java
@@ -5,12 +5,12 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.UnmarkCommand;
-
-import java.util.List;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations

--- a/src/test/java/seedu/address/logic/parser/UnmarkCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnmarkCommandParserTest.java
@@ -1,33 +1,37 @@
-//package seedu.address.logic.parser;
-//
-//import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-//import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
-//import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-//import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
-//
-//import org.junit.jupiter.api.Test;
-//
-//import seedu.address.logic.commands.UnmarkCommand;
-//
-///**
-// * As we are only doing white-box testing, our test cases do not cover path variations
-// * outside of the UnmarkCommand code. For example, inputs "1" and "1 abc" take the
-// * same path through the UnmarkCommand, and therefore we test only one of them.
-// * The path variation for those two cases occur inside the ParserUtil, and
-// * therefore should be covered by the ParserUtilTest.
-// */
-//public class UnmarkCommandParserTest {
-//
-//    private UnmarkCommandParser parser = new UnmarkCommandParser();
-//
-//    @Test
-//    public void parse_validArgs_returnsUnmarkCommand() {
-//        assertParseSuccess(parser, "1", new UnmarkCommand(INDEX_FIRST_TASK));
-//    }
-//
-//    @Test
-//    public void parse_invalidArgs_throwsParseException() {
-//        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkCommand.MESSAGE_USAGE));
-//    }
-//}
-//
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.UnmarkCommand;
+
+import java.util.List;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the UnmarkCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the UnmarkCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class UnmarkCommandParserTest {
+
+    private UnmarkCommandParser parser = new UnmarkCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsUnmarkCommand() {
+        List<Index> indexList = List.of(INDEX_FIRST_TASK);
+        assertParseSuccess(parser, "1", new UnmarkCommand(indexList));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkCommand.MESSAGE_USAGE));
+    }
+}
+

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -10,4 +10,5 @@ public class TypicalIndexes {
     public static final Index INDEX_SECOND_TASK = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_TASK = Index.fromOneBased(3);
     public static final Index INDEX_FIFTH_TASK = Index.fromOneBased(5);
+    public static final Index INDEX_SIXTH_TASK = Index.fromOneBased(6);
 }

--- a/src/test/java/seedu/address/testutil/TypicalTasks.java
+++ b/src/test/java/seedu/address/testutil/TypicalTasks.java
@@ -62,6 +62,11 @@ public class TypicalTasks {
             .withDescription("Assignment 2").withDeadline("2022-03-20")
             .withPriority("low").withCompletionStatus("false").build();
 
+    public static final Task CS2102_MEETING = new TaskBuilder().withName("CS2102 MEETING")
+            .withDescription("Meeting").withDeadline("2022-04-06")
+            .withPriority("medium").withCompletionStatus("true").build();
+
+
     // Manually added - Task's details found in {@code CommandTestUtil}
     public static final Task CS2103T_TUTORIAL = new TaskBuilder().withName(VALID_NAME_TUTORIAL)
             .withDescription(VALID_DESCRIPTION_TUTORIAL).withDeadline(VALID_DEADLINE_TUTORIAL)
@@ -89,7 +94,7 @@ public class TypicalTasks {
 
     public static List<Task> getTypicalTasks() {
         return new ArrayList<>(Arrays.asList(CS2103T_PROJECT, CS2106_FINALS, CS2105_MIDTERM,
-                CS2107_TUTORIAL, MEET_ALICE));
+                CS2107_TUTORIAL, MEET_ALICE, CS2102_MEETING));
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/TypicalTasks.java
+++ b/src/test/java/seedu/address/testutil/TypicalTasks.java
@@ -62,7 +62,7 @@ public class TypicalTasks {
             .withDescription("Assignment 2").withDeadline("2022-03-20")
             .withPriority("low").withCompletionStatus("false").build();
 
-    public static final Task CS2102_MEETING = new TaskBuilder().withName("CS2102 MEETING")
+    public static final Task CS2102_MEETING = new TaskBuilder().withName("CS2102 Meeting")
             .withDescription("Meeting").withDeadline("2022-04-06")
             .withPriority("medium").withCompletionStatus("true").build();
 


### PR DESCRIPTION
Added tests:
- MarkCommandTest
- UnmarkCommandTest
- MarkCommandParserTest
- UnmarkCommandParserTest
- MassOpsParserTest
- HarmoniaTest (mark, unmark, delete)

Edited:
- TypicalTasks (added tasks 5 and 6 that are completed tasks)
- TypicalIndexes
- MassOpsParser added assertions
- MarkCommand and UnmarkCommand changed indexesToString to use StringBuilder instead